### PR TITLE
Fix pipe docs to refer to pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ Note: it works right to left, so the first transformation used is filter and the
 ## pipe
 This is a classic composition function that can be used to assemble multiple functions that take an iterable and return an iterable.
 ```js
-const iter = compose(
+const iter = pipe(
   filter((x % 2) === 0),
   map((x) =>  x + 3)
 )


### PR DESCRIPTION
Quick docs update - looks like a bad copy + paste.