### PR TITLE
Allow interleave to be passed options for the interleaver

### DIFF
--- a/src/$interleave.d.ts
+++ b/src/$interleave.d.ts
@@ -1,6 +1,9 @@
 import { $InputIterable, $GeneratorIterator, $Iterable, $Promise } from './internal/$iterable';
 import $InterleaveBuffer from './internal/interleave/$buffer';
 
+// Without options:
+// #############
+
 // prettier-ignore
 declare function $interleave<T1 = any, T2 = any, R = any>(
   gen: (
@@ -89,6 +92,116 @@ declare function $interleave<T, R>(
     canTakeAny: () => $Promise<$InterleaveBuffer<T> | null>,
     ...buffers: Array<$InterleaveBuffer<T>>
   ) => $Iterable<R>,
+  ...iterables: Array<$InputIterable<T>>
+): $GeneratorIterator<R>;
+
+// With options:
+// #############
+
+// prettier-ignore
+declare function $interleave<O extends {}, T1 = any, T2 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => $Promise<$InterleaveBuffer<T1 | T2> | null>,
+    b1: $InterleaveBuffer<T1>,
+    b2: $InterleaveBuffer<T2>,
+  ) => $Iterable<R>,
+  options: O,
+): (
+  i1: $InputIterable<T1>,
+  i2: $InputIterable<T2>
+) => $GeneratorIterator<R>;
+
+declare function $interleave<O extends {}, T1 = any, T2 = any, T3 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => $Promise<$InterleaveBuffer<T1 | T2 | T3> | null>,
+    b1: $InterleaveBuffer<T1>,
+    b2: $InterleaveBuffer<T2>,
+    b3: $InterleaveBuffer<T3>,
+  ) => $Iterable<R>,
+  options: O,
+): (
+  i1: $InputIterable<T1>,
+  i2: $InputIterable<T2>,
+  i3: $InputIterable<T3>,
+) => $GeneratorIterator<R>;
+
+declare function $interleave<O extends {}, T1 = any, T2 = any, T3 = any, T4 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => $Promise<$InterleaveBuffer<T1 | T2 | T3 | T4> | null>,
+    b1: $InterleaveBuffer<T1>,
+    b2: $InterleaveBuffer<T2>,
+    b3: $InterleaveBuffer<T3>,
+    b4: $InterleaveBuffer<T4>,
+  ) => $Iterable<R>,
+  options: O,
+): (
+  i1: $InputIterable<T1>,
+  i2: $InputIterable<T2>,
+  i3: $InputIterable<T3>,
+  i4: $InputIterable<T4>,
+) => $GeneratorIterator<R>;
+
+declare function $interleave<O extends {}, T, R>(
+  gen: (
+    options: O,
+    canTakeAny: () => $Promise<$InterleaveBuffer<T> | null>,
+    ...buffers: Array<$InterleaveBuffer<T>>
+  ) => $Iterable<R>,
+  options: O,
+): (...iterables: Array<$InputIterable<T>>) => $GeneratorIterator<R>;
+
+declare function $interleave<O extends {}, T1 = any, T2 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => $Promise<$InterleaveBuffer<T1 | T2> | null>,
+    b1: $InterleaveBuffer<T1>,
+    b2: $InterleaveBuffer<T2>,
+  ) => $Iterable<R>,
+  options: O,
+  i1: $InputIterable<T1>,
+  i2: $InputIterable<T2>,
+): $GeneratorIterator<R>;
+
+declare function $interleave<O extends {}, T1 = any, T2 = any, T3 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => $Promise<$InterleaveBuffer<T1 | T2 | T3> | null>,
+    b1: $InterleaveBuffer<T1>,
+    b2: $InterleaveBuffer<T2>,
+    b3: $InterleaveBuffer<T3>,
+  ) => $Iterable<R>,
+  options: O,
+  i1: $InputIterable<T1>,
+  i2: $InputIterable<T2>,
+  i3: $InputIterable<T3>,
+): $GeneratorIterator<R>;
+
+declare function $interleave<O extends {}, T1 = any, T2 = any, T3 = any, T4 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => $Promise<$InterleaveBuffer<T1 | T2 | T3 | T4> | null>,
+    b1: $InterleaveBuffer<T1>,
+    b2: $InterleaveBuffer<T2>,
+    b3: $InterleaveBuffer<T3>,
+    b4: $InterleaveBuffer<T4>,
+  ) => $Iterable<R>,
+  options: O,
+  i1: $InputIterable<T1>,
+  i2: $InputIterable<T2>,
+  i3: $InputIterable<T3>,
+  i4: $InputIterable<T4>,
+): $GeneratorIterator<R>;
+
+declare function $interleave<O extends {}, T, R>(
+  gen: (
+    options: O,
+    canTakeAny: () => $Promise<$InterleaveBuffer<T> | null>,
+    ...buffers: Array<$InterleaveBuffer<T>>
+  ) => $Iterable<R>,
+  options: O,
   ...iterables: Array<$InputIterable<T>>
 ): $GeneratorIterator<R>;
 

--- a/src/__spec__/$interleave.spec.ts
+++ b/src/__spec__/$interleave.spec.ts
@@ -5,6 +5,9 @@ import { $GeneratorIterator, $Promise } from  '../internal/$iterable';
 import $InterleaveBuffer from '../internal/interleave/$buffer';
 import { $interleave } from '..';
 
+// Without options
+// ############
+
 assert<
   $GeneratorIterator<string | number>
 >(
@@ -26,7 +29,7 @@ assert<
         assert<$Promise<number>>(b2.take())
         yield $await(b2.take())
       }
-    })
+    }),
   )(['foo'], [2])
 )
 
@@ -98,5 +101,110 @@ assert<
         yield $await(b4.take())
       }
     })
+  )(['foo'], [2], [(_: any) => _], [{}])
+)
+
+// With options
+// ############
+
+assert<
+  $GeneratorIterator<string | number>
+>(
+  $interleave(
+    $async(function * (
+      options: {},
+      canTakeAny: Function,
+      b1: $InterleaveBuffer<string>,
+      b2: $InterleaveBuffer<number>
+    ) {
+      assert<$Promise<boolean>>(b1.canTake())
+      assert<$Promise<string | undefined>>(b1.take())
+      if ($await(b1.canTake())) {
+        assert<$Promise<string>>(b1.take())
+        yield $await(b1.take())
+      }
+      assert<$Promise<boolean>>(b2.canTake())
+      assert<$Promise<number | undefined>>(b2.take())
+      if ($await(b2.canTake())) {
+        assert<$Promise<number>>(b2.take())
+        yield $await(b2.take())
+      }
+    }),
+    {}
+  )(['foo'], [2])
+)
+
+assert<
+  $GeneratorIterator<string | number | Function>
+>(
+  $interleave(
+    $async(function * (
+      options: {},
+      canTakeAny: Function,
+      b1: $InterleaveBuffer<string>,
+      b2: $InterleaveBuffer<number>,
+      b3: $InterleaveBuffer<Function>
+    ) {
+      assert<$Promise<boolean>>(b1.canTake())
+      assert<$Promise<string | undefined>>(b1.take())
+      if ($await(b1.canTake())) {
+        assert<$Promise<string>>(b1.take())
+        yield $await(b1.take())
+      }
+      assert<$Promise<boolean>>(b2.canTake())
+      assert<$Promise<number | undefined>>(b2.take())
+      if ($await(b2.canTake())) {
+        assert<$Promise<number>>(b2.take())
+        yield $await(b2.take())
+      }
+      assert<$Promise<boolean>>(b3.canTake())
+      assert<$Promise<Function | undefined>>(b3.take())
+      if ($await(b3.canTake())) {
+        assert<$Promise<Function>>(b3.take())
+        yield $await(b3.take())
+      }
+    }),
+    {}
+  )(['foo'], [2], [(_: any) => _])
+)
+
+assert<
+  $GeneratorIterator<string | number | Function | {}>
+>(
+  $interleave(
+    $async(function * (
+      options: {},
+      canTakeAny: Function,
+      b1: $InterleaveBuffer<string>,
+      b2: $InterleaveBuffer<number>,
+      b3: $InterleaveBuffer<Function>,
+      b4: $InterleaveBuffer<{}>
+    ) {
+      assert<$Promise<boolean>>(b1.canTake())
+      assert<$Promise<string | undefined>>(b1.take())
+      if ($await(b1.canTake())) {
+        assert<$Promise<string>>(b1.take())
+        yield $await(b1.take())
+      }
+      assert<$Promise<boolean>>(b2.canTake())
+      assert<$Promise<number | undefined>>(b2.take())
+      if ($await(b2.canTake())) {
+        assert<$Promise<number>>(b2.take())
+        yield $await(b2.take())
+      }
+      assert<$Promise<boolean>>(b3.canTake())
+      assert<$Promise<Function | undefined>>(b3.take())
+      if ($await(b3.canTake())) {
+        assert<$Promise<Function>>(b3.take())
+        yield $await(b3.take())
+      }
+      assert<$Promise<boolean>>(b4.canTake())
+      assert<$Promise<{} | undefined>>(b4.take())
+      if ($await(b4.canTake())) {
+        assert<$Promise<{}>>(b4.take())
+        yield $await(b4.take())
+      }
+    }),
+    {}
   )(['foo'], [2], [(_: any) => _], [{}])
 )

--- a/src/__spec__/async-interleave.spec.ts
+++ b/src/__spec__/async-interleave.spec.ts
@@ -9,7 +9,9 @@
 import assert from 'static-type-assert';
 import { AsyncGeneratorIterator, AsyncPromise } from '../internal/async-iterable';
 import AsyncInterleaveBuffer from '../internal/interleave/async-buffer';
-import { asyncInterleave } from '..';
+import { asyncInterleave } from '..'; // Without options
+// ############
+
 assert<AsyncGeneratorIterator<string | number>>(
   asyncInterleave(async function*(
     canTakeAny: Function,
@@ -105,4 +107,108 @@ assert<AsyncGeneratorIterator<string | number | Function | {}>>(
       yield await b4.take();
     }
   })(['foo'], [2], [(_: any) => _], [{}]),
+); // With options
+// ############
+
+assert<AsyncGeneratorIterator<string | number>>(
+  asyncInterleave(async function*(
+    options: {},
+    canTakeAny: Function,
+    b1: AsyncInterleaveBuffer<string>,
+    b2: AsyncInterleaveBuffer<number>,
+  ) {
+    assert<AsyncPromise<boolean>>(b1.canTake());
+    assert<AsyncPromise<string | undefined>>(b1.take());
+
+    if (await b1.canTake()) {
+      assert<AsyncPromise<string>>(b1.take());
+      yield await b1.take();
+    }
+
+    assert<AsyncPromise<boolean>>(b2.canTake());
+    assert<AsyncPromise<number | undefined>>(b2.take());
+
+    if (await b2.canTake()) {
+      assert<AsyncPromise<number>>(b2.take());
+      yield await b2.take();
+    }
+  },
+  {})(['foo'], [2]),
+);
+assert<AsyncGeneratorIterator<string | number | Function>>(
+  asyncInterleave(async function*(
+    options: {},
+    canTakeAny: Function,
+    b1: AsyncInterleaveBuffer<string>,
+    b2: AsyncInterleaveBuffer<number>,
+    b3: AsyncInterleaveBuffer<Function>,
+  ) {
+    assert<AsyncPromise<boolean>>(b1.canTake());
+    assert<AsyncPromise<string | undefined>>(b1.take());
+
+    if (await b1.canTake()) {
+      assert<AsyncPromise<string>>(b1.take());
+      yield await b1.take();
+    }
+
+    assert<AsyncPromise<boolean>>(b2.canTake());
+    assert<AsyncPromise<number | undefined>>(b2.take());
+
+    if (await b2.canTake()) {
+      assert<AsyncPromise<number>>(b2.take());
+      yield await b2.take();
+    }
+
+    assert<AsyncPromise<boolean>>(b3.canTake());
+    assert<AsyncPromise<Function | undefined>>(b3.take());
+
+    if (await b3.canTake()) {
+      assert<AsyncPromise<Function>>(b3.take());
+      yield await b3.take();
+    }
+  },
+  {})(['foo'], [2], [(_: any) => _]),
+);
+assert<AsyncGeneratorIterator<string | number | Function | {}>>(
+  asyncInterleave(async function*(
+    options: {},
+    canTakeAny: Function,
+    b1: AsyncInterleaveBuffer<string>,
+    b2: AsyncInterleaveBuffer<number>,
+    b3: AsyncInterleaveBuffer<Function>,
+    b4: AsyncInterleaveBuffer<{}>,
+  ) {
+    assert<AsyncPromise<boolean>>(b1.canTake());
+    assert<AsyncPromise<string | undefined>>(b1.take());
+
+    if (await b1.canTake()) {
+      assert<AsyncPromise<string>>(b1.take());
+      yield await b1.take();
+    }
+
+    assert<AsyncPromise<boolean>>(b2.canTake());
+    assert<AsyncPromise<number | undefined>>(b2.take());
+
+    if (await b2.canTake()) {
+      assert<AsyncPromise<number>>(b2.take());
+      yield await b2.take();
+    }
+
+    assert<AsyncPromise<boolean>>(b3.canTake());
+    assert<AsyncPromise<Function | undefined>>(b3.take());
+
+    if (await b3.canTake()) {
+      assert<AsyncPromise<Function>>(b3.take());
+      yield await b3.take();
+    }
+
+    assert<AsyncPromise<boolean>>(b4.canTake());
+    assert<AsyncPromise<{} | undefined>>(b4.take());
+
+    if (await b4.canTake()) {
+      assert<AsyncPromise<{}>>(b4.take());
+      yield await b4.take();
+    }
+  },
+  {})(['foo'], [2], [(_: any) => _], [{}]),
 );

--- a/src/__spec__/interleave.spec.ts
+++ b/src/__spec__/interleave.spec.ts
@@ -9,7 +9,9 @@
 import assert from 'static-type-assert';
 import { GeneratorIterator, Promise } from '../internal/iterable';
 import InterleaveBuffer from '../internal/interleave/buffer';
-import { interleave } from '..';
+import { interleave } from '..'; // Without options
+// ############
+
 assert<GeneratorIterator<string | number>>(
   interleave(function*(
     canTakeAny: Function,
@@ -105,4 +107,108 @@ assert<GeneratorIterator<string | number | Function | {}>>(
       yield b4.take();
     }
   })(['foo'], [2], [(_: any) => _], [{}]),
+); // With options
+// ############
+
+assert<GeneratorIterator<string | number>>(
+  interleave(function*(
+    options: {},
+    canTakeAny: Function,
+    b1: InterleaveBuffer<string>,
+    b2: InterleaveBuffer<number>,
+  ) {
+    assert<Promise<boolean>>(b1.canTake());
+    assert<Promise<string | undefined>>(b1.take());
+
+    if (b1.canTake()) {
+      assert<Promise<string>>(b1.take());
+      yield b1.take();
+    }
+
+    assert<Promise<boolean>>(b2.canTake());
+    assert<Promise<number | undefined>>(b2.take());
+
+    if (b2.canTake()) {
+      assert<Promise<number>>(b2.take());
+      yield b2.take();
+    }
+  },
+  {})(['foo'], [2]),
+);
+assert<GeneratorIterator<string | number | Function>>(
+  interleave(function*(
+    options: {},
+    canTakeAny: Function,
+    b1: InterleaveBuffer<string>,
+    b2: InterleaveBuffer<number>,
+    b3: InterleaveBuffer<Function>,
+  ) {
+    assert<Promise<boolean>>(b1.canTake());
+    assert<Promise<string | undefined>>(b1.take());
+
+    if (b1.canTake()) {
+      assert<Promise<string>>(b1.take());
+      yield b1.take();
+    }
+
+    assert<Promise<boolean>>(b2.canTake());
+    assert<Promise<number | undefined>>(b2.take());
+
+    if (b2.canTake()) {
+      assert<Promise<number>>(b2.take());
+      yield b2.take();
+    }
+
+    assert<Promise<boolean>>(b3.canTake());
+    assert<Promise<Function | undefined>>(b3.take());
+
+    if (b3.canTake()) {
+      assert<Promise<Function>>(b3.take());
+      yield b3.take();
+    }
+  },
+  {})(['foo'], [2], [(_: any) => _]),
+);
+assert<GeneratorIterator<string | number | Function | {}>>(
+  interleave(function*(
+    options: {},
+    canTakeAny: Function,
+    b1: InterleaveBuffer<string>,
+    b2: InterleaveBuffer<number>,
+    b3: InterleaveBuffer<Function>,
+    b4: InterleaveBuffer<{}>,
+  ) {
+    assert<Promise<boolean>>(b1.canTake());
+    assert<Promise<string | undefined>>(b1.take());
+
+    if (b1.canTake()) {
+      assert<Promise<string>>(b1.take());
+      yield b1.take();
+    }
+
+    assert<Promise<boolean>>(b2.canTake());
+    assert<Promise<number | undefined>>(b2.take());
+
+    if (b2.canTake()) {
+      assert<Promise<number>>(b2.take());
+      yield b2.take();
+    }
+
+    assert<Promise<boolean>>(b3.canTake());
+    assert<Promise<Function | undefined>>(b3.take());
+
+    if (b3.canTake()) {
+      assert<Promise<Function>>(b3.take());
+      yield b3.take();
+    }
+
+    assert<Promise<boolean>>(b4.canTake());
+    assert<Promise<{} | undefined>>(b4.take());
+
+    if (b4.canTake()) {
+      assert<Promise<{}>>(b4.take());
+      yield b4.take();
+    }
+  },
+  {})(['foo'], [2], [(_: any) => _], [{}]),
 );

--- a/src/__tests__/$interleave.test.js
+++ b/src/__tests__/$interleave.test.js
@@ -1,14 +1,12 @@
 import { $isAsync, $async, $await } from '../../generate/async.macro';
-import { $Promise } from '../internal/$iterable';
+import { $Promise, $Iterable } from '../internal/$iterable';
 import { $interleave, $InterleaveBuffer, $toArray, asyncToArray } from '..';
 
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-const $methodName = $isAsync ? 'asyncInterleave' : 'interleave';
-
-describe($methodName, () => {
+describe($async`interleave`, () => {
   const a = [1, 2, 3];
   const b = [4, 5, 6];
   const c = [7, 8, 9];
@@ -32,6 +30,26 @@ describe($methodName, () => {
       );
 
       expect($await($toArray(roundRobin(a, b, c)))).toEqual([1, 4, 7, 2, 5, 8, 3, 6, 9]);
+    }),
+  );
+
+  it(
+    'can be passed options for the generator',
+    $async(() => {
+      const options = {};
+
+      expect.assertions(1);
+      $await(
+        $toArray(
+          $interleave(
+            $async(function*(o: {}): $Iterable<any> {
+              expect(o).toBe(options);
+            }),
+            options,
+            null,
+          ),
+        ),
+      );
     }),
   );
 

--- a/src/__tests__/async-interleave.spec.ts
+++ b/src/__tests__/async-interleave.spec.ts
@@ -6,15 +6,14 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { AsyncPromise } from '../internal/async-iterable';
+import { AsyncPromise, AsyncIterable } from '../internal/async-iterable';
 import { asyncInterleave, AsyncInterleaveBuffer, asyncToArray } from '..';
 
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-const asyncMethodName = 'asyncInterleave';
-describe(asyncMethodName, () => {
+describe('asyncInterleave', () => {
   const a = [1, 2, 3];
   const b = [4, 5, 6];
   const c = [7, 8, 9];
@@ -32,6 +31,19 @@ describe(asyncMethodName, () => {
       }
     });
     expect(await asyncToArray(roundRobin(a, b, c))).toEqual([1, 4, 7, 2, 5, 8, 3, 6, 9]);
+  });
+  it('can be passed options for the generator', async () => {
+    const options = {};
+    expect.assertions(1);
+    await asyncToArray(
+      asyncInterleave(
+        async function*(o: {}): AsyncIterable<any> {
+          expect(o).toBe(options);
+        },
+        options,
+        null,
+      ),
+    );
   });
   it('can use the return value of canTakeAny to interleave by promise readiness', async () => {
     const interleaveReady = asyncInterleave(async function*(canTakeAny) {

--- a/src/__tests__/async-interleave.test.js
+++ b/src/__tests__/async-interleave.test.js
@@ -8,15 +8,14 @@
 
 /* eslint-disable no-unused-vars,import/no-duplicates */
 
-import { AsyncPromise } from '../internal/async-iterable';
+import { AsyncPromise, AsyncIterable } from '../internal/async-iterable';
 import { asyncInterleave, AsyncInterleaveBuffer, asyncToArray } from '..';
 
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-const asyncMethodName = 'asyncInterleave';
-describe(asyncMethodName, () => {
+describe('asyncInterleave', () => {
   const a = [1, 2, 3];
   const b = [4, 5, 6];
   const c = [7, 8, 9];
@@ -34,6 +33,19 @@ describe(asyncMethodName, () => {
       }
     });
     expect(await asyncToArray(roundRobin(a, b, c))).toEqual([1, 4, 7, 2, 5, 8, 3, 6, 9]);
+  });
+  it('can be passed options for the generator', async () => {
+    const options = {};
+    expect.assertions(1);
+    await asyncToArray(
+      asyncInterleave(
+        async function*(o: {}): AsyncIterable<any> {
+          expect(o).toBe(options);
+        },
+        options,
+        null,
+      ),
+    );
   });
   it('can use the return value of canTakeAny to interleave by promise readiness', async () => {
     const interleaveReady = asyncInterleave(async function*(canTakeAny) {

--- a/src/__tests__/interleave.spec.ts
+++ b/src/__tests__/interleave.spec.ts
@@ -6,15 +6,14 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { Promise } from '../internal/iterable';
+import { Promise, Iterable } from '../internal/iterable';
 import { interleave, InterleaveBuffer, toArray, asyncToArray } from '..';
 
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-const methodName = 'interleave';
-describe(methodName, () => {
+describe('interleave', () => {
   const a = [1, 2, 3];
   const b = [4, 5, 6];
   const c = [7, 8, 9];
@@ -32,6 +31,19 @@ describe(methodName, () => {
       }
     });
     expect(toArray(roundRobin(a, b, c))).toEqual([1, 4, 7, 2, 5, 8, 3, 6, 9]);
+  });
+  it('can be passed options for the generator', () => {
+    const options = {};
+    expect.assertions(1);
+    toArray(
+      interleave(
+        function*(o: {}): Iterable<any> {
+          expect(o).toBe(options);
+        },
+        options,
+        null,
+      ),
+    );
   });
   it('can use the return value of canTakeAny to do concatenation', () => {
     const concatenate = interleave(function*(

--- a/src/__tests__/interleave.test.js
+++ b/src/__tests__/interleave.test.js
@@ -8,15 +8,14 @@
 
 /* eslint-disable no-unused-vars,import/no-duplicates */
 
-import { Promise } from '../internal/iterable';
+import { Promise, Iterable } from '../internal/iterable';
 import { interleave, InterleaveBuffer, toArray, asyncToArray } from '..';
 
 function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-const methodName = 'interleave';
-describe(methodName, () => {
+describe('interleave', () => {
   const a = [1, 2, 3];
   const b = [4, 5, 6];
   const c = [7, 8, 9];
@@ -34,6 +33,19 @@ describe(methodName, () => {
       }
     });
     expect(toArray(roundRobin(a, b, c))).toEqual([1, 4, 7, 2, 5, 8, 3, 6, 9]);
+  });
+  it('can be passed options for the generator', () => {
+    const options = {};
+    expect.assertions(1);
+    toArray(
+      interleave(
+        function*(o: {}): Iterable<any> {
+          expect(o).toBe(options);
+        },
+        options,
+        null,
+      ),
+    );
   });
   it('can use the return value of canTakeAny to do concatenation', () => {
     const concatenate = interleave(function*(

--- a/src/async-interleave.d.ts
+++ b/src/async-interleave.d.ts
@@ -12,15 +12,11 @@ import {
   AsyncIterable,
   AsyncPromise,
 } from './internal/async-iterable';
-import AsyncInterleaveBuffer from "./internal/interleave/async-buffer"; // prettier-ignore
+import AsyncInterleaveBuffer from './internal/interleave/async-buffer'; // Without options:
+// #############
+// prettier-ignore
 
-declare function asyncInterleave<T1 = any, T2 = any, R = any>(
-  gen: (
-    canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2> | null>,
-    b1: AsyncInterleaveBuffer<T1>,
-    b2: AsyncInterleaveBuffer<T2>,
-  ) => AsyncIterable<R>,
-): (i1: AsyncInputIterable<T1>, i2: AsyncInputIterable<T2>) => AsyncGeneratorIterator<R>;
+declare function asyncInterleave<T1 = any, T2 = any, R = any>(gen: (canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2> | null>, b1: AsyncInterleaveBuffer<T1>, b2: AsyncInterleaveBuffer<T2>) => AsyncIterable<R>): (i1: AsyncInputIterable<T1>, i2: AsyncInputIterable<T2>) => AsyncGeneratorIterator<R>;
 declare function asyncInterleave<T1 = any, T2 = any, T3 = any, R = any>(
   gen: (
     canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2 | T3> | null>,
@@ -91,6 +87,96 @@ declare function asyncInterleave<T, R>(
     canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T> | null>,
     ...buffers: Array<AsyncInterleaveBuffer<T>>
   ) => AsyncIterable<R>,
+  ...iterables: Array<AsyncInputIterable<T>>
+): AsyncGeneratorIterator<R>; // With options:
+// #############
+// prettier-ignore
+
+declare function asyncInterleave<O extends {}, T1 = any, T2 = any, R = any>(gen: (options: O, canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2> | null>, b1: AsyncInterleaveBuffer<T1>, b2: AsyncInterleaveBuffer<T2>) => AsyncIterable<R>, options: O): (i1: AsyncInputIterable<T1>, i2: AsyncInputIterable<T2>) => AsyncGeneratorIterator<R>;
+declare function asyncInterleave<O extends {}, T1 = any, T2 = any, T3 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2 | T3> | null>,
+    b1: AsyncInterleaveBuffer<T1>,
+    b2: AsyncInterleaveBuffer<T2>,
+    b3: AsyncInterleaveBuffer<T3>,
+  ) => AsyncIterable<R>,
+  options: O,
+): (
+  i1: AsyncInputIterable<T1>,
+  i2: AsyncInputIterable<T2>,
+  i3: AsyncInputIterable<T3>,
+) => AsyncGeneratorIterator<R>;
+declare function asyncInterleave<O extends {}, T1 = any, T2 = any, T3 = any, T4 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2 | T3 | T4> | null>,
+    b1: AsyncInterleaveBuffer<T1>,
+    b2: AsyncInterleaveBuffer<T2>,
+    b3: AsyncInterleaveBuffer<T3>,
+    b4: AsyncInterleaveBuffer<T4>,
+  ) => AsyncIterable<R>,
+  options: O,
+): (
+  i1: AsyncInputIterable<T1>,
+  i2: AsyncInputIterable<T2>,
+  i3: AsyncInputIterable<T3>,
+  i4: AsyncInputIterable<T4>,
+) => AsyncGeneratorIterator<R>;
+declare function asyncInterleave<O extends {}, T, R>(
+  gen: (
+    options: O,
+    canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T> | null>,
+    ...buffers: Array<AsyncInterleaveBuffer<T>>
+  ) => AsyncIterable<R>,
+  options: O,
+): (...iterables: Array<AsyncInputIterable<T>>) => AsyncGeneratorIterator<R>;
+declare function asyncInterleave<O extends {}, T1 = any, T2 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2> | null>,
+    b1: AsyncInterleaveBuffer<T1>,
+    b2: AsyncInterleaveBuffer<T2>,
+  ) => AsyncIterable<R>,
+  options: O,
+  i1: AsyncInputIterable<T1>,
+  i2: AsyncInputIterable<T2>,
+): AsyncGeneratorIterator<R>;
+declare function asyncInterleave<O extends {}, T1 = any, T2 = any, T3 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2 | T3> | null>,
+    b1: AsyncInterleaveBuffer<T1>,
+    b2: AsyncInterleaveBuffer<T2>,
+    b3: AsyncInterleaveBuffer<T3>,
+  ) => AsyncIterable<R>,
+  options: O,
+  i1: AsyncInputIterable<T1>,
+  i2: AsyncInputIterable<T2>,
+  i3: AsyncInputIterable<T3>,
+): AsyncGeneratorIterator<R>;
+declare function asyncInterleave<O extends {}, T1 = any, T2 = any, T3 = any, T4 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T1 | T2 | T3 | T4> | null>,
+    b1: AsyncInterleaveBuffer<T1>,
+    b2: AsyncInterleaveBuffer<T2>,
+    b3: AsyncInterleaveBuffer<T3>,
+    b4: AsyncInterleaveBuffer<T4>,
+  ) => AsyncIterable<R>,
+  options: O,
+  i1: AsyncInputIterable<T1>,
+  i2: AsyncInputIterable<T2>,
+  i3: AsyncInputIterable<T3>,
+  i4: AsyncInputIterable<T4>,
+): AsyncGeneratorIterator<R>;
+declare function asyncInterleave<O extends {}, T, R>(
+  gen: (
+    options: O,
+    canTakeAny: () => AsyncPromise<AsyncInterleaveBuffer<T> | null>,
+    ...buffers: Array<AsyncInterleaveBuffer<T>>
+  ) => AsyncIterable<R>,
+  options: O,
   ...iterables: Array<AsyncInputIterable<T>>
 ): AsyncGeneratorIterator<R>;
 export default asyncInterleave;

--- a/src/interleave.d.ts
+++ b/src/interleave.d.ts
@@ -7,15 +7,11 @@
  */
 
 import { InputIterable, GeneratorIterator, Iterable, Promise } from './internal/iterable';
-import InterleaveBuffer from "./internal/interleave/buffer"; // prettier-ignore
+import InterleaveBuffer from './internal/interleave/buffer'; // Without options:
+// #############
+// prettier-ignore
 
-declare function interleave<T1 = any, T2 = any, R = any>(
-  gen: (
-    canTakeAny: () => Promise<InterleaveBuffer<T1 | T2> | null>,
-    b1: InterleaveBuffer<T1>,
-    b2: InterleaveBuffer<T2>,
-  ) => Iterable<R>,
-): (i1: InputIterable<T1>, i2: InputIterable<T2>) => GeneratorIterator<R>;
+declare function interleave<T1 = any, T2 = any, R = any>(gen: (canTakeAny: () => Promise<InterleaveBuffer<T1 | T2> | null>, b1: InterleaveBuffer<T1>, b2: InterleaveBuffer<T2>) => Iterable<R>): (i1: InputIterable<T1>, i2: InputIterable<T2>) => GeneratorIterator<R>;
 declare function interleave<T1 = any, T2 = any, T3 = any, R = any>(
   gen: (
     canTakeAny: () => Promise<InterleaveBuffer<T1 | T2 | T3> | null>,
@@ -82,6 +78,92 @@ declare function interleave<T, R>(
     canTakeAny: () => Promise<InterleaveBuffer<T> | null>,
     ...buffers: Array<InterleaveBuffer<T>>
   ) => Iterable<R>,
+  ...iterables: Array<InputIterable<T>>
+): GeneratorIterator<R>; // With options:
+// #############
+// prettier-ignore
+
+declare function interleave<O extends {}, T1 = any, T2 = any, R = any>(gen: (options: O, canTakeAny: () => Promise<InterleaveBuffer<T1 | T2> | null>, b1: InterleaveBuffer<T1>, b2: InterleaveBuffer<T2>) => Iterable<R>, options: O): (i1: InputIterable<T1>, i2: InputIterable<T2>) => GeneratorIterator<R>;
+declare function interleave<O extends {}, T1 = any, T2 = any, T3 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => Promise<InterleaveBuffer<T1 | T2 | T3> | null>,
+    b1: InterleaveBuffer<T1>,
+    b2: InterleaveBuffer<T2>,
+    b3: InterleaveBuffer<T3>,
+  ) => Iterable<R>,
+  options: O,
+): (i1: InputIterable<T1>, i2: InputIterable<T2>, i3: InputIterable<T3>) => GeneratorIterator<R>;
+declare function interleave<O extends {}, T1 = any, T2 = any, T3 = any, T4 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => Promise<InterleaveBuffer<T1 | T2 | T3 | T4> | null>,
+    b1: InterleaveBuffer<T1>,
+    b2: InterleaveBuffer<T2>,
+    b3: InterleaveBuffer<T3>,
+    b4: InterleaveBuffer<T4>,
+  ) => Iterable<R>,
+  options: O,
+): (
+  i1: InputIterable<T1>,
+  i2: InputIterable<T2>,
+  i3: InputIterable<T3>,
+  i4: InputIterable<T4>,
+) => GeneratorIterator<R>;
+declare function interleave<O extends {}, T, R>(
+  gen: (
+    options: O,
+    canTakeAny: () => Promise<InterleaveBuffer<T> | null>,
+    ...buffers: Array<InterleaveBuffer<T>>
+  ) => Iterable<R>,
+  options: O,
+): (...iterables: Array<InputIterable<T>>) => GeneratorIterator<R>;
+declare function interleave<O extends {}, T1 = any, T2 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => Promise<InterleaveBuffer<T1 | T2> | null>,
+    b1: InterleaveBuffer<T1>,
+    b2: InterleaveBuffer<T2>,
+  ) => Iterable<R>,
+  options: O,
+  i1: InputIterable<T1>,
+  i2: InputIterable<T2>,
+): GeneratorIterator<R>;
+declare function interleave<O extends {}, T1 = any, T2 = any, T3 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => Promise<InterleaveBuffer<T1 | T2 | T3> | null>,
+    b1: InterleaveBuffer<T1>,
+    b2: InterleaveBuffer<T2>,
+    b3: InterleaveBuffer<T3>,
+  ) => Iterable<R>,
+  options: O,
+  i1: InputIterable<T1>,
+  i2: InputIterable<T2>,
+  i3: InputIterable<T3>,
+): GeneratorIterator<R>;
+declare function interleave<O extends {}, T1 = any, T2 = any, T3 = any, T4 = any, R = any>(
+  gen: (
+    options: O,
+    canTakeAny: () => Promise<InterleaveBuffer<T1 | T2 | T3 | T4> | null>,
+    b1: InterleaveBuffer<T1>,
+    b2: InterleaveBuffer<T2>,
+    b3: InterleaveBuffer<T3>,
+    b4: InterleaveBuffer<T4>,
+  ) => Iterable<R>,
+  options: O,
+  i1: InputIterable<T1>,
+  i2: InputIterable<T2>,
+  i3: InputIterable<T3>,
+  i4: InputIterable<T4>,
+): GeneratorIterator<R>;
+declare function interleave<O extends {}, T, R>(
+  gen: (
+    options: O,
+    canTakeAny: () => Promise<InterleaveBuffer<T> | null>,
+    ...buffers: Array<InterleaveBuffer<T>>
+  ) => Iterable<R>,
+  options: O,
   ...iterables: Array<InputIterable<T>>
 ): GeneratorIterator<R>;
 export default interleave;

--- a/src/internal/async-iterable.mjs
+++ b/src/internal/async-iterable.mjs
@@ -42,12 +42,13 @@ AsyncIterable.prototype = Object.assign(Object.create(BaseIterable.prototype), {
 });
 
 function combineFunctionConfig(fn, fnConfig) {
-  const { variadic, reduces, minArgs, maxArgs, forceSync } = fnConfig;
+  const { variadic, reduces, optionalArgsAtEnd, minArgs, maxArgs, forceSync } = fnConfig;
 
   return {
     fn,
     variadic: !!variadic,
     reduces: !!reduces,
+    optionalArgsAtEnd: !!optionalArgsAtEnd,
     minArgs: minArgs === undefined ? fn.length - 1 : minArgs,
     maxArgs: maxArgs === undefined ? fn.length - 1 : maxArgs,
     isIterable: isValidAsyncIterableArgument,

--- a/src/internal/curry.mjs
+++ b/src/internal/curry.mjs
@@ -7,11 +7,11 @@ export function curry(fn, expectedArgsLength = fn.length, appliedArgs = []) {
   };
 }
 
-function unshiftUndefineds(args, by) {
-  if (by) {
+function insertUndefineds(args, at, count) {
+  if (count > 0) {
     const argsLength = args.length;
-    for (let i = argsLength - 1; i >= 0; i--) {
-      args[i + by] = args[i];
+    for (let i = argsLength - 1; i >= at; i--) {
+      args[i + count] = args[i];
       args[i] = undefined;
     }
   }
@@ -22,6 +22,7 @@ function variadicCurryWithValidationInner(config, args) {
     fn,
     variadic,
     reduces,
+    optionalArgsAtEnd,
     minArgs,
     maxArgs,
     isIterable,
@@ -61,11 +62,15 @@ function variadicCurryWithValidationInner(config, args) {
         args[i] = applyOnIterableArgs(args[i]);
       }
 
-      unshiftUndefineds(args, maxArgs - iterableArgsStart);
+      insertUndefineds(
+        args,
+        optionalArgsAtEnd ? iterableArgsStart : 0,
+        maxArgs - iterableArgsStart,
+      );
 
       if (variadic) {
-        const iterableArgs = args.slice(iterableArgsStart);
-        args.splice(iterableArgsStart);
+        const iterableArgs = args.slice(maxArgs);
+        args.splice(maxArgs);
 
         return reduces ? fn(...args, iterableArgs) : new IterableClass(config, args, iterableArgs);
       } else {

--- a/src/internal/iterable.mjs
+++ b/src/internal/iterable.mjs
@@ -66,12 +66,13 @@ Iterable.prototype = Object.assign(Object.create(BaseIterable.prototype), {
 });
 
 function combineFunctionConfig(fn, fnConfig) {
-  const { variadic, reduces, minArgs, maxArgs } = fnConfig;
+  const { variadic, reduces, optionalArgsAtEnd, minArgs, maxArgs } = fnConfig;
 
   return {
     fn,
     variadic: !!variadic,
     reduces: !!reduces,
+    optionalArgsAtEnd: !!optionalArgsAtEnd,
     minArgs: minArgs === undefined ? fn.length - 1 : minArgs,
     maxArgs: maxArgs === undefined ? fn.length - 1 : maxArgs,
     isIterable: isValidIterableArgument,


### PR DESCRIPTION
The goal is to ensure that it is not necessary to use a closure to pass options to interleave's generator. It is normal for an interleaving function to have parameters, and our collate functions built on top of interleave will be no exception.