### PR TITLE
stop travis building every branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
-  - "10"
+  - '10'
 
 script: npm run verify
+branches:
+  only:
+    - master


### PR DESCRIPTION
This was just obnoxious. Why kick off two jobs on the same commit? And once merged to master that's a third copy of the same job. I've also reenabled branch protection on the travis build and required that branches be up to date before merging.