### PR TITLE
Remove n from fork

### DIFF
--- a/API.md
+++ b/API.md
@@ -2010,14 +2010,9 @@ for (const response of asyncThrottle(100, pollHealth)) {
 
 ### fork
 
-**fork(n, [source](#sourceiterable))**  
 **fork([source](#sourceiterable))**
 
-Defaults:
-
-`n`: `Infinity`
-
-Returns an iterable of `n` forks of `source`. Each fork contains the same values as `source`, and can be consumed independently. This works even if `source` cannot itself be consumed more than once, for example because it is a generator. Values are buffered until they have been consumed by all forks. Each fork can only be consumed once.
+Returns an iterable of `forks` of `source`. Each fork contains the same values as `source`, and can be consumed independently. This works even if `source` cannot itself be consumed more than once, for example because it is a generator. Values are buffered until they have been consumed by all forks. Each fork can only be consumed once. Note that fork caches values, and these cached values can never be released until `forks.return()` is called on the iterable of forks. If you are consuming `forks` using destructuring syntax (as in this example) or a `for..of` loop, this is done for you.
 
 ```js
 const [forkA, forkB, forkC] = fork(function* () {
@@ -2041,13 +2036,10 @@ forkC.next().value; // 3
 
 **WARNING**
 
-There is a really good chance that you'd be better off using `toArray` to cache an iterable instead of `fork`. `fork` is only better when you have a known, finite number of consumers of an infinite (or very large) iterable, and in particular when your consumers consume in parallel. These conditions will be rare, and if they are not met, `fork` will end up being slower and using more memory than `toArray` anyway.
-
-If your use case does satisfy the above conditions, be sure that `fork` understands how many consumers to create, either by using `slice` or destructuring on the forks iterable, or by passing the `n` argument to `fork`.
+There is a really good chance that you'd be better off using `toArray` to cache an iterable instead of `fork`. `fork` is only better when you have multiple consumers of an infinite (or very large) iterable, and you are sure that they will be consuming in parallel.
 
 ### asyncFork
 
-**asyncFork(n, [source](#asyncsourceiterable))**  
 **asyncFork([source](#asyncsourceiterable))**
 
 See [fork](#fork)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - `joinAsStringWith`, `asyncJoinAsStringWith` (Instead use `str(joinWith(sep, ...))`)
  - `regexpExec`
 
+**Arguments**
+ - `n` from `fork` and `asyncFork`. Use destructuring or call `return()` on the forks iterable.
+
 **Exports**
  - `InterleaveBuffer`, `AsyncInterleaveBuffer`
 

--- a/src/impls/$fork/$fork.d.ts
+++ b/src/impls/$fork/$fork.d.ts
@@ -3,13 +3,4 @@ import { $SourceIterable, $ResultIterable } from '../../types/$iterable';
 
 declare function $fork<T>(source: $SourceIterable<T>): SyncResultIterable<$ResultIterable<T>>;
 
-declare function $fork<T>(
-  n: number,
-): (source: $SourceIterable<T>) => SyncResultIterable<$ResultIterable<T>>;
-
-declare function $fork<T>(
-  n: number,
-  source: $SourceIterable<T>,
-): SyncResultIterable<$ResultIterable<T>>;
-
 export default $fork;

--- a/src/impls/$fork/$fork.js
+++ b/src/impls/$fork/$fork.js
@@ -1,6 +1,6 @@
 import { $isAsync, $async, $await, $iteratorSymbol } from '../../../generate/async.macro.cjs';
 
-import { $ensureIterable, $isIterable, $callReturn } from '../../internal/$iterable.js';
+import { $iterableCurry, $callReturn } from '../../internal/$iterable.js';
 import { Exchange } from './internal/exchange.js';
 
 function fetch(state) {
@@ -62,11 +62,13 @@ function* generateFork(state, consumer) {
   }
 }
 
-function* generateForks(state, n) {
+function* generateForks(source, state) {
   const { exchange } = state;
 
+  state.iterator = source[$iteratorSymbol]();
+
   try {
-    for (let counter = 0; counter < n; counter++) {
+    while (true) {
       const fork = generateFork(state, exchange.spawnConsumerAtRoot());
       // this first call to "next" allows to initiate the function generator
       // this ensures that "iterableCounter" will be always increased and decreased
@@ -82,31 +84,18 @@ function* generateForks(state, n) {
   }
 }
 
-export function $fork(source, n = Infinity) {
+export function $fork(source) {
   const state = {
-    iterator: $ensureIterable(source)[$iteratorSymbol](),
+    iterator: null,
     iterableCounter: 0,
     exchange: new Exchange(),
     done: false,
     doneValue: undefined,
   };
 
-  return generateForks(state, n);
+  return generateForks(source, state);
 }
 
-export default function curriedFork(...args) {
-  if (args.length >= 2) {
-    const [n, iterable] = args;
-    return $fork(iterable, n);
-  }
-
-  if (args.length === 0) {
-    return $fork;
-  }
-
-  if ($isIterable(args[0])) {
-    return $fork(args[0], undefined);
-  } else {
-    return (iterable) => $fork(iterable, args[0]);
-  }
-}
+export default $iterableCurry($fork, {
+  forceSync: true,
+});

--- a/src/impls/$fork/DOCME.json
+++ b/src/impls/$fork/DOCME.json
@@ -1,7 +1,3 @@
 {
-  "type": "cache",
-  "signatures": [
-    [{ "name": "n" }, { "name": "source", "isIterable": true }],
-    [{ "name": "source", "isIterable": true }]
-  ]
+  "type": "cache"
 }

--- a/src/impls/$fork/README.md
+++ b/src/impls/$fork/README.md
@@ -1,8 +1,4 @@
-Defaults:
-
-`n`: `Infinity`
-
-Returns an iterable of `n` forks of `source`. Each fork contains the same values as `source`, and can be consumed independently. This works even if `source` cannot itself be consumed more than once, for example because it is a generator. Values are buffered until they have been consumed by all forks. Each fork can only be consumed once.
+Returns an iterable of `forks` of `source`. Each fork contains the same values as `source`, and can be consumed independently. This works even if `source` cannot itself be consumed more than once, for example because it is a generator. Values are buffered until they have been consumed by all forks. Each fork can only be consumed once. Note that fork caches values, and these cached values can never be released until `forks.return()` is called on the iterable of forks. If you are consuming `forks` using destructuring syntax (as in this example) or a `for..of` loop, this is done for you.
 
 ```js
 const [forkA, forkB, forkC] = fork(function* () {
@@ -26,6 +22,4 @@ forkC.next().value; // 3
 
 **WARNING**
 
-There is a really good chance that you'd be better off using `toArray` to cache an iterable instead of `fork`. `fork` is only better when you have a known, finite number of consumers of an infinite (or very large) iterable, and in particular when your consumers consume in parallel. These conditions will be rare, and if they are not met, `fork` will end up being slower and using more memory than `toArray` anyway.
-
-If your use case does satisfy the above conditions, be sure that `fork` understands how many consumers to create, either by using `slice` or destructuring on the forks iterable, or by passing the `n` argument to `fork`.
+There is a really good chance that you'd be better off using `toArray` to cache an iterable instead of `fork`. `fork` is only better when you have multiple consumers of an infinite (or very large) iterable, and you are sure that they will be consuming in parallel.

--- a/src/impls/$fork/__tests__/$fork.test.js
+++ b/src/impls/$fork/__tests__/$fork.test.js
@@ -31,28 +31,6 @@ describe($`fork`, () => {
   );
 
   it(
-    'can take a number as first argument',
-    $async(() => {
-      const gen = $fork(3, $makeIterable());
-      const originalIter = $await($unwrap($makeIterable()));
-      expect($await($unwrap($map((iter) => $unwrap(iter), gen)))).toEqual(
-        Array(3).fill(originalIter),
-      );
-    }),
-  );
-
-  it(
-    'can be curried',
-    $async(() => {
-      const gen = $fork(3)($makeIterable());
-      const originalIter = $await($unwrap($makeIterable()));
-      expect($await($unwrap($map((iter) => $unwrap(iter), gen)))).toEqual(
-        Array(3).fill(originalIter),
-      );
-    }),
-  );
-
-  it(
     'does not matter which order the fork iterables are consumed in',
     $async(() => {
       const [a, b, c] = $fork($makeIterable());

--- a/src/impls/$fork/__tests__/async-fork.auto.spec.ts
+++ b/src/impls/$fork/__tests__/async-fork.auto.spec.ts
@@ -25,22 +25,6 @@ describe('asyncFork', () => {
     );
   });
 
-  it('can take a number as first argument', async () => {
-    const gen = asyncFork(3, asyncMakeIterable());
-    const originalIter = await asyncUnwrap(asyncMakeIterable());
-    expect(await asyncUnwrap(asyncMap((iter) => asyncUnwrap(iter), gen))).toEqual(
-      Array(3).fill(originalIter),
-    );
-  });
-
-  it('can be curried', async () => {
-    const gen = asyncFork(3)(asyncMakeIterable());
-    const originalIter = await asyncUnwrap(asyncMakeIterable());
-    expect(await asyncUnwrap(asyncMap((iter) => asyncUnwrap(iter), gen))).toEqual(
-      Array(3).fill(originalIter),
-    );
-  });
-
   it('does not matter which order the fork iterables are consumed in', async () => {
     const [a, b, c] = asyncFork(asyncMakeIterable());
     const originalIter = await asyncUnwrap(asyncMakeIterable());

--- a/src/impls/$fork/__tests__/async-fork.test.js
+++ b/src/impls/$fork/__tests__/async-fork.test.js
@@ -25,22 +25,6 @@ describe('asyncFork', () => {
     );
   });
 
-  it('can take a number as first argument', async () => {
-    const gen = asyncFork(3, asyncMakeIterable());
-    const originalIter = await asyncUnwrap(asyncMakeIterable());
-    expect(await asyncUnwrap(asyncMap((iter) => asyncUnwrap(iter), gen))).toEqual(
-      Array(3).fill(originalIter),
-    );
-  });
-
-  it('can be curried', async () => {
-    const gen = asyncFork(3)(asyncMakeIterable());
-    const originalIter = await asyncUnwrap(asyncMakeIterable());
-    expect(await asyncUnwrap(asyncMap((iter) => asyncUnwrap(iter), gen))).toEqual(
-      Array(3).fill(originalIter),
-    );
-  });
-
   it('does not matter which order the fork iterables are consumed in', async () => {
     const [a, b, c] = asyncFork(asyncMakeIterable());
     const originalIter = await asyncUnwrap(asyncMakeIterable());

--- a/src/impls/$fork/__tests__/fork.auto.spec.ts
+++ b/src/impls/$fork/__tests__/fork.auto.spec.ts
@@ -23,18 +23,6 @@ describe('fork', () => {
     expect(unwrap(map((iter) => unwrap(iter), [a, b, c]))).toEqual(Array(3).fill(originalIter));
   });
 
-  it('can take a number as first argument', () => {
-    const gen = fork(3, makeIterable());
-    const originalIter = unwrap(makeIterable());
-    expect(unwrap(map((iter) => unwrap(iter), gen))).toEqual(Array(3).fill(originalIter));
-  });
-
-  it('can be curried', () => {
-    const gen = fork(3)(makeIterable());
-    const originalIter = unwrap(makeIterable());
-    expect(unwrap(map((iter) => unwrap(iter), gen))).toEqual(Array(3).fill(originalIter));
-  });
-
   it('does not matter which order the fork iterables are consumed in', () => {
     const [a, b, c] = fork(makeIterable());
     const originalIter = unwrap(makeIterable());

--- a/src/impls/$fork/__tests__/fork.test.js
+++ b/src/impls/$fork/__tests__/fork.test.js
@@ -23,18 +23,6 @@ describe('fork', () => {
     expect(unwrap(map((iter) => unwrap(iter), [a, b, c]))).toEqual(Array(3).fill(originalIter));
   });
 
-  it('can take a number as first argument', () => {
-    const gen = fork(3, makeIterable());
-    const originalIter = unwrap(makeIterable());
-    expect(unwrap(map((iter) => unwrap(iter), gen))).toEqual(Array(3).fill(originalIter));
-  });
-
-  it('can be curried', () => {
-    const gen = fork(3)(makeIterable());
-    const originalIter = unwrap(makeIterable());
-    expect(unwrap(map((iter) => unwrap(iter), gen))).toEqual(Array(3).fill(originalIter));
-  });
-
   it('does not matter which order the fork iterables are consumed in', () => {
     const [a, b, c] = fork(makeIterable());
     const originalIter = unwrap(makeIterable());

--- a/src/impls/$fork/async-fork.d.ts
+++ b/src/impls/$fork/async-fork.d.ts
@@ -13,13 +13,4 @@ declare function asyncFork<T>(
   source: AsyncSourceIterable<T>,
 ): SyncResultIterable<AsyncResultIterable<T>>;
 
-declare function asyncFork<T>(
-  n: number,
-): (source: AsyncSourceIterable<T>) => SyncResultIterable<AsyncResultIterable<T>>;
-
-declare function asyncFork<T>(
-  n: number,
-  source: AsyncSourceIterable<T>,
-): SyncResultIterable<AsyncResultIterable<T>>;
-
 export default asyncFork;

--- a/src/impls/$fork/fork.d.ts
+++ b/src/impls/$fork/fork.d.ts
@@ -14,13 +14,4 @@ import {
 
 declare function fork<T>(source: SourceIterable<T>): SyncResultIterable<ResultIterable<T>>;
 
-declare function fork<T>(
-  n: number,
-): (source: SourceIterable<T>) => SyncResultIterable<ResultIterable<T>>;
-
-declare function fork<T>(
-  n: number,
-  source: SourceIterable<T>,
-): SyncResultIterable<ResultIterable<T>>;
-
 export default fork;


### PR DESCRIPTION
@sithmel Had noted that fork was too complicated. So I simplified it.
The docs read more plainly now.
There is no more custom currying.
This resolves ambiguity between `n` and `iterable` when the value `undefined` was passed. Did that mean you wanted to use the default `n = Infinity`, or that you were intending to create forks of an empty iterable?