### PR TITLE
iter-tools-es

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [7.0.0-rc.1] - UNRELEASED
 ### Removed
 **Folders**
- - `es2015`: It is expected that most users will switch to `import ... from '@iter-tools/es'`.
+ - `es2015`: It is expected that most users will switch to `import ... from 'iter-tools-es'`.
 
 **Methods**
  - `joinAsString`, `asyncJoinAsString` (Instead use `str(join(...))`)
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Renamed
 **Folders**
- - `es2018` moved to separate package: `@iter-tools/es` (note the `@`).
-   - e.g. `import { map } from 'iter-tools/es2018` is now `import { map } from '@iter-tools/es`
+ - `es2018` moved to separate package: `iter-tools-es` (note the `@`).
+   - e.g. `import { map } from 'iter-tools/es2018` is now `import { map } from 'iter-tools-es`
 
 **Methods**
  - `last`, `asyncLast` to `takeLast`, `asyncTakeLast`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build status](https://img.shields.io/github/workflow/status/iter-tools/iter-tools/verify)](https://github.com/iter-tools/iter-tools/actions?query=branch%3Atrunk+workflow%3Averify)
 [![line coverage](https://codecov.io/gh/iter-tools/iter-tools/branch/trunk/graph/badge.svg)](https://codecov.io/gh/iter-tools/iter-tools)
-[![npm version](https://img.shields.io/npm/v/@iter-tools/es)](https://www.npmjs.com/package/@iter-tools/es)
+[![npm version](https://img.shields.io/npm/v/iter-tools-es)](https://www.npmjs.com/package/iter-tools-es)
 [![chat on gitter](https://img.shields.io/gitter/room/iter-tools/iter-tools)](https://gitter.im/iter-tools/community)
 
 `iter-tools` provides a comprehensive suite of utility methods for working with javascript iterables and async iterables. Iterables offer an abstraction for describing sequences of values. It you're not sure if `iter-tools` is the right library for you, check out our [features](#features).
@@ -11,8 +11,8 @@
 
 ```js
 // If your environment supports es2018:
-import { filter } from '@iter-tools/es';
-const { filter } = require('@iter-tools/es');
+import { filter } from 'iter-tools-es';
+const { filter } = require('iter-tools-es');
 
 // Otherwise you can use es5:
 import { filter } from 'iter-tools';
@@ -48,7 +48,7 @@ Iterables are usually consumed with the [for..of loop syntax](https://developer.
 Some iterables are also iterators, earning them the name `IterableIterator`. Any iterables returned by `iter-tools` methods (e.g. [filter](https://github.com/iter-tools/iter-tools/blob/trunk/API.md#filter)) are iterable iterators because they are implemented using [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*). This means they can be used in one of two ways:
 
 ```js
-import { filter, notUndefined } from '@iter-tools/es';
+import { filter, notUndefined } from 'iter-tools-es';
 // as an iterable:
 for (const value of filter(notUndefined, iterable)) {
   /* ... */
@@ -72,14 +72,14 @@ class SparseArray extends Array {
 - It has type definitions checked in for Typescript (`>3.6.4`). These are validated on every PR.
 - It is [semver](https://semver.org/) compliant, keeps a [changelog](https://github.com/iter-tools/iter-tools/blob/trunk/CHANGELOG.md), and has no runtime dependencies.
 - `iter-tools` supports [tree-shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking), and is a [commonjs/esmodule dual package](https://nodejs.org/api/packages.html#packages_dual_commonjs_es_module_packages), meaning it can be loaded using `require()` as well as `import`.
-- The library's sources are valid es module code. Node versions `>12.17.0` can execute them and web build systems that transpile code in `node_modules` can consume them as well. This makes it possible to use a github branch as a package, e.g. by putting `"dependencies": { "@iter-tools/es": "gh-username/iter-tools" }` in your `package.json`. Correctly configured bundlers can use a `browserslist` to avoid shipping code that is slower, more cryptic, and harder to debug than it needs to be.
+- The library's sources are valid es module code. Node versions `>12.17.0` can execute them and web build systems that transpile code in `node_modules` can consume them as well. This makes it possible to use a github branch as a package, e.g. by putting `"dependencies": { "iter-tools-es": "gh-username/iter-tools" }` in your `package.json`. Correctly configured bundlers can use a `browserslist` to avoid shipping code that is slower, more cryptic, and harder to debug than it needs to be.
 
 ### Individual Methods
 
 It is possible to import individual methods from the library. This will make the resulting program or application faster to initialize as it avoids the need to parse the whole library (including parts of it which may not be used). Note that this will not be nececssary for code which will be bundled prior to shipping, as modern versions of rollup and webpack will remove the unused code. Importing a single method looks like this:
 
 ```js
-const notUndefined = require('@iter-tools/es/methods/not-undefined');
+const notUndefined = require('iter-tools-es/methods/not-undefined');
 ```
 
 ### explode.macro
@@ -87,11 +87,11 @@ const notUndefined = require('@iter-tools/es/methods/not-undefined');
 If you happen to be transpiling the code and have use of the fantastic `babel-plugin-macros`, you can generate single-method imports effortlessly like so:
 
 ```js
-import { filter, map } from '@iter-tools/es/explode.macro';
+import { filter, map } from 'iter-tools-es/explode.macro';
 
 // which transpiles to:
-import filter from '@iter-tools/es/methods/filter';
-import map from '@iter-tools/es/methods/map';
+import filter from 'iter-tools-es/methods/filter';
+import map from 'iter-tools-es/methods/map';
 ```
 
 ## Roadmap

--- a/generate-yo/generators/method/templates/$-mapping/__tests__/$method.test.js
+++ b/generate-yo/generators/method/templates/$-mapping/__tests__/$method.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $__method__ } from '@iter-tools/es';
+import { $__method__ } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers';
 
 describe($`__method__`, () => {

--- a/generate-yo/generators/method/templates/$-reducing/__tests__/$method.test.js
+++ b/generate-yo/generators/method/templates/$-reducing/__tests__/$method.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $__method__ } from '@iter-tools/es';
+import { $__method__ } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`__method__`, () => {

--- a/generate-yo/generators/method/templates/async-mapping/__tests__/method.test.js
+++ b/generate-yo/generators/method/templates/async-mapping/__tests__/method.test.js
@@ -1,4 +1,4 @@
-import { __method__ } from '@iter-tools/es';
+import { __method__ } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('__method__', () => {

--- a/generate-yo/generators/method/templates/async-reducing/__tests__/method.test.js
+++ b/generate-yo/generators/method/templates/async-reducing/__tests__/method.test.js
@@ -1,4 +1,4 @@
-import { __method__ } from '@iter-tools/es';
+import { __method__ } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('__method__', () => {

--- a/generate-yo/generators/method/templates/sync-mapping/__tests__/method.test.js
+++ b/generate-yo/generators/method/templates/sync-mapping/__tests__/method.test.js
@@ -1,4 +1,4 @@
-import { __method__ } from '@iter-tools/es';
+import { __method__ } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('__method__', () => {

--- a/generate-yo/generators/method/templates/sync-reducing/__tests__/method.test.js
+++ b/generate-yo/generators/method/templates/sync-reducing/__tests__/method.test.js
@@ -1,4 +1,4 @@
-import { __method__ } from '@iter-tools/es';
+import { __method__ } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('__method__', () => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@iter-tools/es",
+  "name": "iter-tools-es",
   "version": "7.0.0-rc.0",
   "description": "The iterable toolbox",
   "type": "module",

--- a/scripts/dist.cjs
+++ b/scripts/dist.cjs
@@ -10,7 +10,7 @@ const target = argv._[0];
 const mungeReadme = (content) => {
   const lines = content.split('\n');
   const npmBadgeIdx = lines.findIndex((line) =>
-    line.includes('https://www.npmjs.com/package/@iter-tools/es'),
+    line.includes('https://www.npmjs.com/package/iter-tools-es'),
   );
   if (npmBadgeIdx >= 0) {
     lines.splice(npmBadgeIdx, 1);

--- a/src/impls/$append/__tests__/$append.test.js
+++ b/src/impls/$append/__tests__/$append.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $append } from '@iter-tools/es';
+import { $append } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`append`, () => {

--- a/src/impls/$append/__tests__/append.auto.spec.ts
+++ b/src/impls/$append/__tests__/append.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { append } from '@iter-tools/es';
+import { append } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('append', () => {

--- a/src/impls/$append/__tests__/append.test.js
+++ b/src/impls/$append/__tests__/append.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { append } from '@iter-tools/es';
+import { append } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('append', () => {

--- a/src/impls/$append/__tests__/async-append.auto.spec.ts
+++ b/src/impls/$append/__tests__/async-append.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncAppend } from '@iter-tools/es';
+import { asyncAppend } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncAppend', () => {

--- a/src/impls/$append/__tests__/async-append.test.js
+++ b/src/impls/$append/__tests__/async-append.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncAppend } from '@iter-tools/es';
+import { asyncAppend } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncAppend', () => {

--- a/src/impls/$batch/__tests__/$batch.test.js
+++ b/src/impls/$batch/__tests__/$batch.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $batch } from '@iter-tools/es';
+import { $batch } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`batch`, () => {

--- a/src/impls/$batch/__tests__/async-batch.auto.spec.ts
+++ b/src/impls/$batch/__tests__/async-batch.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncBatch } from '@iter-tools/es';
+import { asyncBatch } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncBatch', () => {

--- a/src/impls/$batch/__tests__/async-batch.test.js
+++ b/src/impls/$batch/__tests__/async-batch.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncBatch } from '@iter-tools/es';
+import { asyncBatch } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncBatch', () => {

--- a/src/impls/$batch/__tests__/batch.auto.spec.ts
+++ b/src/impls/$batch/__tests__/batch.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { batch } from '@iter-tools/es';
+import { batch } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('batch', () => {

--- a/src/impls/$batch/__tests__/batch.test.js
+++ b/src/impls/$batch/__tests__/batch.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { batch } from '@iter-tools/es';
+import { batch } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('batch', () => {

--- a/src/impls/$collate/__tests__/$collate.test.js
+++ b/src/impls/$collate/__tests__/$collate.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $collate } from '@iter-tools/es';
+import { $collate } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`collate`, () => {

--- a/src/impls/$collate/__tests__/async-collate.auto.spec.ts
+++ b/src/impls/$collate/__tests__/async-collate.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncCollate } from '@iter-tools/es';
+import { asyncCollate } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncCollate', () => {

--- a/src/impls/$collate/__tests__/async-collate.test.js
+++ b/src/impls/$collate/__tests__/async-collate.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncCollate } from '@iter-tools/es';
+import { asyncCollate } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncCollate', () => {

--- a/src/impls/$collate/__tests__/collate.auto.spec.ts
+++ b/src/impls/$collate/__tests__/collate.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { collate } from '@iter-tools/es';
+import { collate } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('collate', () => {

--- a/src/impls/$collate/__tests__/collate.test.js
+++ b/src/impls/$collate/__tests__/collate.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { collate } from '@iter-tools/es';
+import { collate } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('collate', () => {

--- a/src/impls/$compress/__tests__/$compress.test.js
+++ b/src/impls/$compress/__tests__/$compress.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $compress } from '@iter-tools/es';
+import { $compress } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`compress`, () => {

--- a/src/impls/$compress/__tests__/async-compress.auto.spec.ts
+++ b/src/impls/$compress/__tests__/async-compress.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncCompress } from '@iter-tools/es';
+import { asyncCompress } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncCompress', () => {

--- a/src/impls/$compress/__tests__/async-compress.test.js
+++ b/src/impls/$compress/__tests__/async-compress.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncCompress } from '@iter-tools/es';
+import { asyncCompress } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncCompress', () => {

--- a/src/impls/$compress/__tests__/compress.auto.spec.ts
+++ b/src/impls/$compress/__tests__/compress.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { compress } from '@iter-tools/es';
+import { compress } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('compress', () => {

--- a/src/impls/$compress/__tests__/compress.test.js
+++ b/src/impls/$compress/__tests__/compress.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { compress } from '@iter-tools/es';
+import { compress } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('compress', () => {

--- a/src/impls/$concat/__tests__/$concat.test.js
+++ b/src/impls/$concat/__tests__/$concat.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $concat } from '@iter-tools/es';
+import { $concat } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`concat`, () => {

--- a/src/impls/$concat/__tests__/async-concat.auto.spec.ts
+++ b/src/impls/$concat/__tests__/async-concat.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncConcat } from '@iter-tools/es';
+import { asyncConcat } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncConcat', () => {

--- a/src/impls/$concat/__tests__/async-concat.test.js
+++ b/src/impls/$concat/__tests__/async-concat.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncConcat } from '@iter-tools/es';
+import { asyncConcat } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncConcat', () => {

--- a/src/impls/$concat/__tests__/concat.auto.spec.ts
+++ b/src/impls/$concat/__tests__/concat.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { concat } from '@iter-tools/es';
+import { concat } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('concat', () => {

--- a/src/impls/$concat/__tests__/concat.test.js
+++ b/src/impls/$concat/__tests__/concat.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { concat } from '@iter-tools/es';
+import { concat } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('concat', () => {

--- a/src/impls/$consume/__tests__/$consume.deprecated.test.js
+++ b/src/impls/$consume/__tests__/$consume.deprecated.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $consume } from '@iter-tools/es';
+import { $consume } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`consume (deprecated)`, () => {

--- a/src/impls/$consume/__tests__/$consume.test.js
+++ b/src/impls/$consume/__tests__/$consume.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $consume } from '@iter-tools/es';
+import { $consume } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`consume`, () => {

--- a/src/impls/$consume/__tests__/async-consume.auto.spec.ts
+++ b/src/impls/$consume/__tests__/async-consume.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncConsume } from '@iter-tools/es';
+import { asyncConsume } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncConsume', () => {

--- a/src/impls/$consume/__tests__/async-consume.deprecated.test.js
+++ b/src/impls/$consume/__tests__/async-consume.deprecated.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncConsume } from '@iter-tools/es';
+import { asyncConsume } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncConsume (deprecated)', () => {

--- a/src/impls/$consume/__tests__/async-consume.test.js
+++ b/src/impls/$consume/__tests__/async-consume.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncConsume } from '@iter-tools/es';
+import { asyncConsume } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncConsume', () => {

--- a/src/impls/$consume/__tests__/consume.auto.spec.ts
+++ b/src/impls/$consume/__tests__/consume.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { consume } from '@iter-tools/es';
+import { consume } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('consume', () => {

--- a/src/impls/$consume/__tests__/consume.deprecated.test.js
+++ b/src/impls/$consume/__tests__/consume.deprecated.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { consume } from '@iter-tools/es';
+import { consume } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('consume (deprecated)', () => {

--- a/src/impls/$consume/__tests__/consume.test.js
+++ b/src/impls/$consume/__tests__/consume.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { consume } from '@iter-tools/es';
+import { consume } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('consume', () => {

--- a/src/impls/$cycle-times/__tests__/$cycle-times.test.js
+++ b/src/impls/$cycle-times/__tests__/$cycle-times.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $cycleTimes } from '@iter-tools/es';
+import { $cycleTimes } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`cycleTimes`, () => {

--- a/src/impls/$cycle-times/__tests__/async-cycle-times.auto.spec.ts
+++ b/src/impls/$cycle-times/__tests__/async-cycle-times.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncCycleTimes } from '@iter-tools/es';
+import { asyncCycleTimes } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncCycleTimes', () => {

--- a/src/impls/$cycle-times/__tests__/async-cycle-times.test.js
+++ b/src/impls/$cycle-times/__tests__/async-cycle-times.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncCycleTimes } from '@iter-tools/es';
+import { asyncCycleTimes } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncCycleTimes', () => {

--- a/src/impls/$cycle-times/__tests__/cycle-times.auto.spec.ts
+++ b/src/impls/$cycle-times/__tests__/cycle-times.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { cycleTimes } from '@iter-tools/es';
+import { cycleTimes } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('cycleTimes', () => {

--- a/src/impls/$cycle-times/__tests__/cycle-times.test.js
+++ b/src/impls/$cycle-times/__tests__/cycle-times.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { cycleTimes } from '@iter-tools/es';
+import { cycleTimes } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('cycleTimes', () => {

--- a/src/impls/$cycle/__tests__/$cycle.spec.ts
+++ b/src/impls/$cycle/__tests__/$cycle.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 import { $ResultIterable } from '../../../types/$iterable';
-import { $cycle } from '@iter-tools/es';
+import { $cycle } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$cycle/__tests__/$cycle.test.js
+++ b/src/impls/$cycle/__tests__/$cycle.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $cycle, $slice } from '@iter-tools/es';
+import { $cycle, $slice } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`cycle`, () => {

--- a/src/impls/$cycle/__tests__/async-cycle.auto.spec.ts
+++ b/src/impls/$cycle/__tests__/async-cycle.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncCycle, asyncSlice } from '@iter-tools/es';
+import { asyncCycle, asyncSlice } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncCycle', () => {

--- a/src/impls/$cycle/__tests__/async-cycle.spec.ts
+++ b/src/impls/$cycle/__tests__/async-cycle.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { AsyncResultIterable } from '../../../types/async-iterable';
-import { asyncCycle } from '@iter-tools/es';
+import { asyncCycle } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$cycle/__tests__/async-cycle.test.js
+++ b/src/impls/$cycle/__tests__/async-cycle.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncCycle, asyncSlice } from '@iter-tools/es';
+import { asyncCycle, asyncSlice } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncCycle', () => {

--- a/src/impls/$cycle/__tests__/cycle.auto.spec.ts
+++ b/src/impls/$cycle/__tests__/cycle.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { cycle, slice } from '@iter-tools/es';
+import { cycle, slice } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('cycle', () => {

--- a/src/impls/$cycle/__tests__/cycle.spec.ts
+++ b/src/impls/$cycle/__tests__/cycle.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { ResultIterable } from '../../../types/iterable';
-import { cycle } from '@iter-tools/es';
+import { cycle } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$cycle/__tests__/cycle.test.js
+++ b/src/impls/$cycle/__tests__/cycle.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { cycle, slice } from '@iter-tools/es';
+import { cycle, slice } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('cycle', () => {

--- a/src/impls/$drop-while/__tests__/$drop-while.test.js
+++ b/src/impls/$drop-while/__tests__/$drop-while.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $dropWhile } from '@iter-tools/es';
+import { $dropWhile } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`dropWhile`, () => {

--- a/src/impls/$drop-while/__tests__/async-drop-while.auto.spec.ts
+++ b/src/impls/$drop-while/__tests__/async-drop-while.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncDropWhile } from '@iter-tools/es';
+import { asyncDropWhile } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncDropWhile', () => {

--- a/src/impls/$drop-while/__tests__/async-drop-while.test.js
+++ b/src/impls/$drop-while/__tests__/async-drop-while.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncDropWhile } from '@iter-tools/es';
+import { asyncDropWhile } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncDropWhile', () => {

--- a/src/impls/$drop-while/__tests__/drop-while.auto.spec.ts
+++ b/src/impls/$drop-while/__tests__/drop-while.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { dropWhile } from '@iter-tools/es';
+import { dropWhile } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('dropWhile', () => {

--- a/src/impls/$drop-while/__tests__/drop-while.test.js
+++ b/src/impls/$drop-while/__tests__/drop-while.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { dropWhile } from '@iter-tools/es';
+import { dropWhile } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('dropWhile', () => {

--- a/src/impls/$drop/__tests__/$drop.test.js
+++ b/src/impls/$drop/__tests__/$drop.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $drop } from '@iter-tools/es';
+import { $drop } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`drop`, () => {

--- a/src/impls/$drop/__tests__/async-drop.auto.spec.ts
+++ b/src/impls/$drop/__tests__/async-drop.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncDrop } from '@iter-tools/es';
+import { asyncDrop } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncDrop', () => {

--- a/src/impls/$drop/__tests__/async-drop.test.js
+++ b/src/impls/$drop/__tests__/async-drop.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncDrop } from '@iter-tools/es';
+import { asyncDrop } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncDrop', () => {

--- a/src/impls/$drop/__tests__/drop.auto.spec.ts
+++ b/src/impls/$drop/__tests__/drop.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { drop } from '@iter-tools/es';
+import { drop } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('drop', () => {

--- a/src/impls/$drop/__tests__/drop.test.js
+++ b/src/impls/$drop/__tests__/drop.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { drop } from '@iter-tools/es';
+import { drop } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('drop', () => {

--- a/src/impls/$enumerate/__tests__/$enumerate.test.js
+++ b/src/impls/$enumerate/__tests__/$enumerate.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $enumerate } from '@iter-tools/es';
+import { $enumerate } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`enumerate`, () => {

--- a/src/impls/$enumerate/__tests__/async-enumerate.auto.spec.ts
+++ b/src/impls/$enumerate/__tests__/async-enumerate.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncEnumerate } from '@iter-tools/es';
+import { asyncEnumerate } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncEnumerate', () => {

--- a/src/impls/$enumerate/__tests__/async-enumerate.test.js
+++ b/src/impls/$enumerate/__tests__/async-enumerate.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncEnumerate } from '@iter-tools/es';
+import { asyncEnumerate } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncEnumerate', () => {

--- a/src/impls/$enumerate/__tests__/enumerate.auto.spec.ts
+++ b/src/impls/$enumerate/__tests__/enumerate.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { enumerate } from '@iter-tools/es';
+import { enumerate } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('enumerate', () => {

--- a/src/impls/$enumerate/__tests__/enumerate.test.js
+++ b/src/impls/$enumerate/__tests__/enumerate.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { enumerate } from '@iter-tools/es';
+import { enumerate } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('enumerate', () => {

--- a/src/impls/$equal/__tests__/$equal.test.js
+++ b/src/impls/$equal/__tests__/$equal.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $equal } from '@iter-tools/es';
+import { $equal } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`equal`, () => {

--- a/src/impls/$equal/__tests__/async-equal.auto.spec.ts
+++ b/src/impls/$equal/__tests__/async-equal.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncEqual } from '@iter-tools/es';
+import { asyncEqual } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncEqual', () => {

--- a/src/impls/$equal/__tests__/async-equal.test.js
+++ b/src/impls/$equal/__tests__/async-equal.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncEqual } from '@iter-tools/es';
+import { asyncEqual } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncEqual', () => {

--- a/src/impls/$equal/__tests__/equal.auto.spec.ts
+++ b/src/impls/$equal/__tests__/equal.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { equal } from '@iter-tools/es';
+import { equal } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('equal', () => {

--- a/src/impls/$equal/__tests__/equal.test.js
+++ b/src/impls/$equal/__tests__/equal.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { equal } from '@iter-tools/es';
+import { equal } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('equal', () => {

--- a/src/impls/$every/__tests__/$every.test.js
+++ b/src/impls/$every/__tests__/$every.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $every } from '@iter-tools/es';
+import { $every } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`every`, () => {

--- a/src/impls/$every/__tests__/async-every.auto.spec.ts
+++ b/src/impls/$every/__tests__/async-every.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncEvery } from '@iter-tools/es';
+import { asyncEvery } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncEvery', () => {

--- a/src/impls/$every/__tests__/async-every.test.js
+++ b/src/impls/$every/__tests__/async-every.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncEvery } from '@iter-tools/es';
+import { asyncEvery } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncEvery', () => {

--- a/src/impls/$every/__tests__/every.auto.spec.ts
+++ b/src/impls/$every/__tests__/every.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { every } from '@iter-tools/es';
+import { every } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('every', () => {

--- a/src/impls/$every/__tests__/every.test.js
+++ b/src/impls/$every/__tests__/every.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { every } from '@iter-tools/es';
+import { every } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('every', () => {

--- a/src/impls/$filter/__tests__/$filter.spec.ts
+++ b/src/impls/$filter/__tests__/$filter.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'static-type-assert';
 
 import { $Iterable, $ResultIterable } from '../../../types/$iterable';
-import { $filter } from '@iter-tools/es';
+import { $filter } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$filter/__tests__/$filter.test.js
+++ b/src/impls/$filter/__tests__/$filter.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $filter } from '@iter-tools/es';
+import { $filter } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`filter`, () => {

--- a/src/impls/$filter/__tests__/async-filter-parallel.auto.spec.ts
+++ b/src/impls/$filter/__tests__/async-filter-parallel.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFilterParallel } from '@iter-tools/es';
+import { asyncFilterParallel } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncFilterParallel', () => {

--- a/src/impls/$filter/__tests__/async-filter-parallel.test.js
+++ b/src/impls/$filter/__tests__/async-filter-parallel.test.js
@@ -1,4 +1,4 @@
-import { asyncFilterParallel } from '@iter-tools/es';
+import { asyncFilterParallel } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncFilterParallel', () => {

--- a/src/impls/$filter/__tests__/async-filter.auto.spec.ts
+++ b/src/impls/$filter/__tests__/async-filter.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFilter } from '@iter-tools/es';
+import { asyncFilter } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncFilter', () => {

--- a/src/impls/$filter/__tests__/async-filter.spec.ts
+++ b/src/impls/$filter/__tests__/async-filter.spec.ts
@@ -9,7 +9,7 @@
 import assert from 'static-type-assert';
 
 import { AsyncIterable, AsyncResultIterable } from '../../../types/async-iterable';
-import { asyncFilter } from '@iter-tools/es';
+import { asyncFilter } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$filter/__tests__/async-filter.test.js
+++ b/src/impls/$filter/__tests__/async-filter.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFilter } from '@iter-tools/es';
+import { asyncFilter } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncFilter', () => {

--- a/src/impls/$filter/__tests__/filter.auto.spec.ts
+++ b/src/impls/$filter/__tests__/filter.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { filter } from '@iter-tools/es';
+import { filter } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('filter', () => {

--- a/src/impls/$filter/__tests__/filter.spec.ts
+++ b/src/impls/$filter/__tests__/filter.spec.ts
@@ -9,7 +9,7 @@
 import assert from 'static-type-assert';
 
 import { Iterable, ResultIterable } from '../../../types/iterable';
-import { filter } from '@iter-tools/es';
+import { filter } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$filter/__tests__/filter.test.js
+++ b/src/impls/$filter/__tests__/filter.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { filter } from '@iter-tools/es';
+import { filter } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('filter', () => {

--- a/src/impls/$find-or/__tests__/$find-or.spec.ts
+++ b/src/impls/$find-or/__tests__/$find-or.spec.ts
@@ -2,7 +2,7 @@ import { $Promise } from '../../../../generate/async.macro.cjs';
 
 import assert from 'static-type-assert';
 import { $Iterable } from '../../../types/$iterable';
-import { $findOr } from '@iter-tools/es';
+import { $findOr } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$find-or/__tests__/$find-or.test.js
+++ b/src/impls/$find-or/__tests__/$find-or.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $findOr } from '@iter-tools/es';
+import { $findOr } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`findOr`, () => {

--- a/src/impls/$find-or/__tests__/async-find-or.auto.spec.ts
+++ b/src/impls/$find-or/__tests__/async-find-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFindOr } from '@iter-tools/es';
+import { asyncFindOr } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncFindOr', () => {

--- a/src/impls/$find-or/__tests__/async-find-or.spec.ts
+++ b/src/impls/$find-or/__tests__/async-find-or.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { AsyncIterable } from '../../../types/async-iterable';
-import { asyncFindOr } from '@iter-tools/es';
+import { asyncFindOr } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$find-or/__tests__/async-find-or.test.js
+++ b/src/impls/$find-or/__tests__/async-find-or.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFindOr } from '@iter-tools/es';
+import { asyncFindOr } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncFindOr', () => {

--- a/src/impls/$find-or/__tests__/find-or.auto.spec.ts
+++ b/src/impls/$find-or/__tests__/find-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { findOr } from '@iter-tools/es';
+import { findOr } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('findOr', () => {

--- a/src/impls/$find-or/__tests__/find-or.spec.ts
+++ b/src/impls/$find-or/__tests__/find-or.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { Iterable } from '../../../types/iterable';
-import { findOr } from '@iter-tools/es';
+import { findOr } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$find-or/__tests__/find-or.test.js
+++ b/src/impls/$find-or/__tests__/find-or.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { findOr } from '@iter-tools/es';
+import { findOr } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('findOr', () => {

--- a/src/impls/$find/__tests__/$find.spec.ts
+++ b/src/impls/$find/__tests__/$find.spec.ts
@@ -2,7 +2,7 @@ import { $Promise } from '../../../../generate/async.macro.cjs';
 
 import assert from 'static-type-assert';
 import { $Iterable } from '../../../types/$iterable';
-import { $find } from '@iter-tools/es';
+import { $find } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$find/__tests__/$find.test.js
+++ b/src/impls/$find/__tests__/$find.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $find } from '@iter-tools/es';
+import { $find } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`find`, () => {

--- a/src/impls/$find/__tests__/async-find.auto.spec.ts
+++ b/src/impls/$find/__tests__/async-find.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFind } from '@iter-tools/es';
+import { asyncFind } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncFind', () => {

--- a/src/impls/$find/__tests__/async-find.spec.ts
+++ b/src/impls/$find/__tests__/async-find.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { AsyncIterable } from '../../../types/async-iterable';
-import { asyncFind } from '@iter-tools/es';
+import { asyncFind } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$find/__tests__/async-find.test.js
+++ b/src/impls/$find/__tests__/async-find.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFind } from '@iter-tools/es';
+import { asyncFind } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncFind', () => {

--- a/src/impls/$find/__tests__/find.auto.spec.ts
+++ b/src/impls/$find/__tests__/find.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { find } from '@iter-tools/es';
+import { find } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('find', () => {

--- a/src/impls/$find/__tests__/find.spec.ts
+++ b/src/impls/$find/__tests__/find.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { Iterable } from '../../../types/iterable';
-import { find } from '@iter-tools/es';
+import { find } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$find/__tests__/find.test.js
+++ b/src/impls/$find/__tests__/find.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { find } from '@iter-tools/es';
+import { find } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('find', () => {

--- a/src/impls/$first-or/__tests__/$first-or.test.js
+++ b/src/impls/$first-or/__tests__/$first-or.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $firstOr } from '@iter-tools/es';
+import { $firstOr } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`firstOr`, () => {

--- a/src/impls/$first-or/__tests__/async-first-or.auto.spec.ts
+++ b/src/impls/$first-or/__tests__/async-first-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFirstOr } from '@iter-tools/es';
+import { asyncFirstOr } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncFirstOr', () => {

--- a/src/impls/$first-or/__tests__/async-first-or.test.js
+++ b/src/impls/$first-or/__tests__/async-first-or.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFirstOr } from '@iter-tools/es';
+import { asyncFirstOr } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncFirstOr', () => {

--- a/src/impls/$first-or/__tests__/first-or.auto.spec.ts
+++ b/src/impls/$first-or/__tests__/first-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { firstOr } from '@iter-tools/es';
+import { firstOr } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('firstOr', () => {

--- a/src/impls/$first-or/__tests__/first-or.test.js
+++ b/src/impls/$first-or/__tests__/first-or.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { firstOr } from '@iter-tools/es';
+import { firstOr } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('firstOr', () => {

--- a/src/impls/$first/__tests__/$first.test.js
+++ b/src/impls/$first/__tests__/$first.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $first } from '@iter-tools/es';
+import { $first } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`first`, () => {

--- a/src/impls/$first/__tests__/async-first.auto.spec.ts
+++ b/src/impls/$first/__tests__/async-first.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFirst } from '@iter-tools/es';
+import { asyncFirst } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncFirst', () => {

--- a/src/impls/$first/__tests__/async-first.test.js
+++ b/src/impls/$first/__tests__/async-first.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFirst } from '@iter-tools/es';
+import { asyncFirst } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncFirst', () => {

--- a/src/impls/$first/__tests__/first.auto.spec.ts
+++ b/src/impls/$first/__tests__/first.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { first } from '@iter-tools/es';
+import { first } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('first', () => {

--- a/src/impls/$first/__tests__/first.test.js
+++ b/src/impls/$first/__tests__/first.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { first } from '@iter-tools/es';
+import { first } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('first', () => {

--- a/src/impls/$flat-map/__tests__/$flat-map.test.js
+++ b/src/impls/$flat-map/__tests__/$flat-map.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $flatMap } from '@iter-tools/es';
+import { $flatMap } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`flatMap`, () => {

--- a/src/impls/$flat-map/__tests__/async-flat-map.auto.spec.ts
+++ b/src/impls/$flat-map/__tests__/async-flat-map.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFlatMap } from '@iter-tools/es';
+import { asyncFlatMap } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncFlatMap', () => {

--- a/src/impls/$flat-map/__tests__/async-flat-map.test.js
+++ b/src/impls/$flat-map/__tests__/async-flat-map.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFlatMap } from '@iter-tools/es';
+import { asyncFlatMap } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncFlatMap', () => {

--- a/src/impls/$flat-map/__tests__/flat-map.auto.spec.ts
+++ b/src/impls/$flat-map/__tests__/flat-map.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { flatMap } from '@iter-tools/es';
+import { flatMap } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('flatMap', () => {

--- a/src/impls/$flat-map/__tests__/flat-map.test.js
+++ b/src/impls/$flat-map/__tests__/flat-map.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { flatMap } from '@iter-tools/es';
+import { flatMap } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('flatMap', () => {

--- a/src/impls/$flat/__tests__/$flat.spec.ts
+++ b/src/impls/$flat/__tests__/$flat.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'static-type-assert';
 
 import { $Iterable, $ResultIterable } from '../../../types/$iterable';
-import { $flat } from '@iter-tools/es';
+import { $flat } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$flat/__tests__/$flat.test.js
+++ b/src/impls/$flat/__tests__/$flat.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $flat } from '@iter-tools/es';
+import { $flat } from 'iter-tools-es';
 import { $wrapDeep, $unwrap, $unwrapDeep, anyType } from '../../../test/$helpers.js';
 
 describe($`flat`, () => {

--- a/src/impls/$flat/__tests__/async-flat.auto.spec.ts
+++ b/src/impls/$flat/__tests__/async-flat.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFlat } from '@iter-tools/es';
+import { asyncFlat } from 'iter-tools-es';
 import {
   asyncWrapDeep,
   asyncUnwrap,

--- a/src/impls/$flat/__tests__/async-flat.spec.ts
+++ b/src/impls/$flat/__tests__/async-flat.spec.ts
@@ -9,7 +9,7 @@
 import assert from 'static-type-assert';
 
 import { AsyncIterable, AsyncResultIterable } from '../../../types/async-iterable';
-import { asyncFlat } from '@iter-tools/es';
+import { asyncFlat } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$flat/__tests__/async-flat.test.js
+++ b/src/impls/$flat/__tests__/async-flat.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFlat } from '@iter-tools/es';
+import { asyncFlat } from 'iter-tools-es';
 import {
   asyncWrapDeep,
   asyncUnwrap,

--- a/src/impls/$flat/__tests__/flat.auto.spec.ts
+++ b/src/impls/$flat/__tests__/flat.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { flat } from '@iter-tools/es';
+import { flat } from 'iter-tools-es';
 import { wrapDeep, unwrap, unwrapDeep, anyType } from '../../../test/helpers.js';
 
 describe('flat', () => {

--- a/src/impls/$flat/__tests__/flat.spec.ts
+++ b/src/impls/$flat/__tests__/flat.spec.ts
@@ -9,7 +9,7 @@
 import assert from 'static-type-assert';
 
 import { Iterable, ResultIterable } from '../../../types/iterable';
-import { flat } from '@iter-tools/es';
+import { flat } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$flat/__tests__/flat.test.js
+++ b/src/impls/$flat/__tests__/flat.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { flat } from '@iter-tools/es';
+import { flat } from 'iter-tools-es';
 import { wrapDeep, unwrap, unwrapDeep, anyType } from '../../../test/helpers.js';
 
 describe('flat', () => {

--- a/src/impls/$for-each/__tests__/$for-each.test.js
+++ b/src/impls/$for-each/__tests__/$for-each.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $forEach } from '@iter-tools/es';
+import { $forEach } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`forEach`, () => {

--- a/src/impls/$for-each/__tests__/async-for-each.auto.spec.ts
+++ b/src/impls/$for-each/__tests__/async-for-each.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncForEach } from '@iter-tools/es';
+import { asyncForEach } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncForEach', () => {

--- a/src/impls/$for-each/__tests__/async-for-each.test.js
+++ b/src/impls/$for-each/__tests__/async-for-each.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncForEach } from '@iter-tools/es';
+import { asyncForEach } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncForEach', () => {

--- a/src/impls/$for-each/__tests__/for-each.auto.spec.ts
+++ b/src/impls/$for-each/__tests__/for-each.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { forEach } from '@iter-tools/es';
+import { forEach } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('forEach', () => {

--- a/src/impls/$for-each/__tests__/for-each.test.js
+++ b/src/impls/$for-each/__tests__/for-each.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { forEach } from '@iter-tools/es';
+import { forEach } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('forEach', () => {

--- a/src/impls/$fork/__tests__/$fork.test.js
+++ b/src/impls/$fork/__tests__/$fork.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await, $iteratorSymbol } from '../../../../generate/async.macro.cjs';
 
-import { $fork, $map } from '@iter-tools/es';
+import { $fork, $map } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`fork`, () => {

--- a/src/impls/$fork/__tests__/async-fork.auto.spec.ts
+++ b/src/impls/$fork/__tests__/async-fork.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFork, asyncMap } from '@iter-tools/es';
+import { asyncFork, asyncMap } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncFork', () => {

--- a/src/impls/$fork/__tests__/async-fork.test.js
+++ b/src/impls/$fork/__tests__/async-fork.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncFork, asyncMap } from '@iter-tools/es';
+import { asyncFork, asyncMap } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncFork', () => {

--- a/src/impls/$fork/__tests__/fork.auto.spec.ts
+++ b/src/impls/$fork/__tests__/fork.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { fork, map } from '@iter-tools/es';
+import { fork, map } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('fork', () => {

--- a/src/impls/$fork/__tests__/fork.test.js
+++ b/src/impls/$fork/__tests__/fork.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { fork, map } from '@iter-tools/es';
+import { fork, map } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('fork', () => {

--- a/src/impls/$group-by/__tests__/$group-by.deprecated.test.js
+++ b/src/impls/$group-by/__tests__/$group-by.deprecated.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $groupBy } from '@iter-tools/es';
+import { $groupBy } from 'iter-tools-es';
 import { $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`groupBy (deprecated)`, () => {

--- a/src/impls/$group-by/__tests__/$group-by.spec.ts
+++ b/src/impls/$group-by/__tests__/$group-by.spec.ts
@@ -2,7 +2,7 @@ import { $Promise } from '../../../../generate/async.macro.cjs';
 
 import assert from 'static-type-assert';
 import { $Iterable, $ResultIterable } from '../../../types/$iterable';
-import { $groupBy } from '@iter-tools/es';
+import { $groupBy } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$group-by/__tests__/$group-by.test.js
+++ b/src/impls/$group-by/__tests__/$group-by.test.js
@@ -1,7 +1,7 @@
 import { $, $async, $await, $Promise } from '../../../../generate/async.macro.cjs';
 import { $awaitError } from '../../../../generate/test.macro.cjs';
 
-import { $groupBy } from '@iter-tools/es';
+import { $groupBy } from 'iter-tools-es';
 import { $wrap, $unwrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 $async;

--- a/src/impls/$group-by/__tests__/async-group-by.auto.spec.ts
+++ b/src/impls/$group-by/__tests__/async-group-by.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncGroupBy } from '@iter-tools/es';
+import { asyncGroupBy } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 async function identity<T>(value: T): Promise<T> {

--- a/src/impls/$group-by/__tests__/async-group-by.deprecated.test.js
+++ b/src/impls/$group-by/__tests__/async-group-by.deprecated.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncGroupBy } from '@iter-tools/es';
+import { asyncGroupBy } from 'iter-tools-es';
 import { asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncGroupBy (deprecated)', () => {

--- a/src/impls/$group-by/__tests__/async-group-by.spec.ts
+++ b/src/impls/$group-by/__tests__/async-group-by.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { AsyncIterable, AsyncResultIterable } from '../../../types/async-iterable';
-import { asyncGroupBy } from '@iter-tools/es';
+import { asyncGroupBy } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$group-by/__tests__/async-group-by.test.js
+++ b/src/impls/$group-by/__tests__/async-group-by.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncGroupBy } from '@iter-tools/es';
+import { asyncGroupBy } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 async function identity<T>(value: T): Promise<T> {

--- a/src/impls/$group-by/__tests__/group-by.auto.spec.ts
+++ b/src/impls/$group-by/__tests__/group-by.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { groupBy } from '@iter-tools/es';
+import { groupBy } from 'iter-tools-es';
 import { wrap, unwrap, unwrapDeep } from '../../../test/helpers.js';
 
 function identity<T>(value: T): T {

--- a/src/impls/$group-by/__tests__/group-by.deprecated.test.js
+++ b/src/impls/$group-by/__tests__/group-by.deprecated.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { groupBy } from '@iter-tools/es';
+import { groupBy } from 'iter-tools-es';
 import { unwrapDeep } from '../../../test/helpers.js';
 
 describe('groupBy (deprecated)', () => {

--- a/src/impls/$group-by/__tests__/group-by.spec.ts
+++ b/src/impls/$group-by/__tests__/group-by.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { Iterable, ResultIterable } from '../../../types/iterable';
-import { groupBy } from '@iter-tools/es';
+import { groupBy } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$group-by/__tests__/group-by.test.js
+++ b/src/impls/$group-by/__tests__/group-by.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { groupBy } from '@iter-tools/es';
+import { groupBy } from 'iter-tools-es';
 import { wrap, unwrap, unwrapDeep } from '../../../test/helpers.js';
 
 function identity<T>(value: T): T {

--- a/src/impls/$group/__tests__/$group.spec.ts
+++ b/src/impls/$group/__tests__/$group.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 import { $Iterable, $ResultIterable } from '../../../types/$iterable';
-import { $group } from '@iter-tools/es';
+import { $group } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$group/__tests__/$group.test.js
+++ b/src/impls/$group/__tests__/$group.test.js
@@ -1,7 +1,7 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 import { $awaitError } from '../../../../generate/test.macro.cjs';
 
-import { $group } from '@iter-tools/es';
+import { $group } from 'iter-tools-es';
 import { $wrap, $unwrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`group`, () => {

--- a/src/impls/$group/__tests__/async-group.auto.spec.ts
+++ b/src/impls/$group/__tests__/async-group.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncGroup } from '@iter-tools/es';
+import { asyncGroup } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncGroup', () => {

--- a/src/impls/$group/__tests__/async-group.spec.ts
+++ b/src/impls/$group/__tests__/async-group.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { AsyncIterable, AsyncResultIterable } from '../../../types/async-iterable';
-import { asyncGroup } from '@iter-tools/es';
+import { asyncGroup } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$group/__tests__/async-group.test.js
+++ b/src/impls/$group/__tests__/async-group.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncGroup } from '@iter-tools/es';
+import { asyncGroup } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncGroup', () => {

--- a/src/impls/$group/__tests__/group.auto.spec.ts
+++ b/src/impls/$group/__tests__/group.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { group } from '@iter-tools/es';
+import { group } from 'iter-tools-es';
 import { wrap, unwrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('group', () => {

--- a/src/impls/$group/__tests__/group.spec.ts
+++ b/src/impls/$group/__tests__/group.spec.ts
@@ -8,7 +8,7 @@
 
 import assert from 'static-type-assert';
 import { Iterable, ResultIterable } from '../../../types/iterable';
-import { group } from '@iter-tools/es';
+import { group } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$group/__tests__/group.test.js
+++ b/src/impls/$group/__tests__/group.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { group } from '@iter-tools/es';
+import { group } from 'iter-tools-es';
 import { wrap, unwrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('group', () => {

--- a/src/impls/$includes-any-seq/__tests__/$includes-any-seq.test.js
+++ b/src/impls/$includes-any-seq/__tests__/$includes-any-seq.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $includesAnySeq } from '@iter-tools/es';
+import { $includesAnySeq } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`includesAnySeq`, () => {

--- a/src/impls/$includes-any-seq/__tests__/async-includes-any-seq.auto.spec.ts
+++ b/src/impls/$includes-any-seq/__tests__/async-includes-any-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIncludesAnySeq } from '@iter-tools/es';
+import { asyncIncludesAnySeq } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIncludesAnySeq', () => {

--- a/src/impls/$includes-any-seq/__tests__/async-includes-any-seq.test.js
+++ b/src/impls/$includes-any-seq/__tests__/async-includes-any-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIncludesAnySeq } from '@iter-tools/es';
+import { asyncIncludesAnySeq } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIncludesAnySeq', () => {

--- a/src/impls/$includes-any-seq/__tests__/includes-any-seq.auto.spec.ts
+++ b/src/impls/$includes-any-seq/__tests__/includes-any-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { includesAnySeq } from '@iter-tools/es';
+import { includesAnySeq } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('includesAnySeq', () => {

--- a/src/impls/$includes-any-seq/__tests__/includes-any-seq.test.js
+++ b/src/impls/$includes-any-seq/__tests__/includes-any-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { includesAnySeq } from '@iter-tools/es';
+import { includesAnySeq } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('includesAnySeq', () => {

--- a/src/impls/$includes-any/__tests__/$includes-any.test.js
+++ b/src/impls/$includes-any/__tests__/$includes-any.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $includesAny } from '@iter-tools/es';
+import { $includesAny } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`includesAny`, () => {

--- a/src/impls/$includes-any/__tests__/async-includes-any.auto.spec.ts
+++ b/src/impls/$includes-any/__tests__/async-includes-any.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIncludesAny } from '@iter-tools/es';
+import { asyncIncludesAny } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIncludesAny', () => {

--- a/src/impls/$includes-any/__tests__/async-includes-any.test.js
+++ b/src/impls/$includes-any/__tests__/async-includes-any.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIncludesAny } from '@iter-tools/es';
+import { asyncIncludesAny } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIncludesAny', () => {

--- a/src/impls/$includes-any/__tests__/includes-any.auto.spec.ts
+++ b/src/impls/$includes-any/__tests__/includes-any.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { includesAny } from '@iter-tools/es';
+import { includesAny } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('includesAny', () => {

--- a/src/impls/$includes-any/__tests__/includes-any.test.js
+++ b/src/impls/$includes-any/__tests__/includes-any.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { includesAny } from '@iter-tools/es';
+import { includesAny } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('includesAny', () => {

--- a/src/impls/$includes-seq/__tests__/$includes-seq.test.js
+++ b/src/impls/$includes-seq/__tests__/$includes-seq.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $includesSeq } from '@iter-tools/es';
+import { $includesSeq } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`includesSeq`, () => {

--- a/src/impls/$includes-seq/__tests__/async-includes-seq.auto.spec.ts
+++ b/src/impls/$includes-seq/__tests__/async-includes-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIncludesSeq } from '@iter-tools/es';
+import { asyncIncludesSeq } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIncludesSeq', () => {

--- a/src/impls/$includes-seq/__tests__/async-includes-seq.test.js
+++ b/src/impls/$includes-seq/__tests__/async-includes-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIncludesSeq } from '@iter-tools/es';
+import { asyncIncludesSeq } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIncludesSeq', () => {

--- a/src/impls/$includes-seq/__tests__/includes-seq.auto.spec.ts
+++ b/src/impls/$includes-seq/__tests__/includes-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { includesSeq } from '@iter-tools/es';
+import { includesSeq } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('includesSeq', () => {

--- a/src/impls/$includes-seq/__tests__/includes-seq.test.js
+++ b/src/impls/$includes-seq/__tests__/includes-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { includesSeq } from '@iter-tools/es';
+import { includesSeq } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('includesSeq', () => {

--- a/src/impls/$includes/__tests__/$includes.test.js
+++ b/src/impls/$includes/__tests__/$includes.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $includes } from '@iter-tools/es';
+import { $includes } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`includes`, () => {

--- a/src/impls/$includes/__tests__/async-includes.auto.spec.ts
+++ b/src/impls/$includes/__tests__/async-includes.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIncludes } from '@iter-tools/es';
+import { asyncIncludes } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIncludes', () => {

--- a/src/impls/$includes/__tests__/async-includes.test.js
+++ b/src/impls/$includes/__tests__/async-includes.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIncludes } from '@iter-tools/es';
+import { asyncIncludes } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIncludes', () => {

--- a/src/impls/$includes/__tests__/includes.auto.spec.ts
+++ b/src/impls/$includes/__tests__/includes.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { includes } from '@iter-tools/es';
+import { includes } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('includes', () => {

--- a/src/impls/$includes/__tests__/includes.test.js
+++ b/src/impls/$includes/__tests__/includes.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { includes } from '@iter-tools/es';
+import { includes } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('includes', () => {

--- a/src/impls/$interleave/__tests__/$interleave.test.js
+++ b/src/impls/$interleave/__tests__/$interleave.test.js
@@ -2,7 +2,7 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
 import { $Iterable } from '../../../types/$iterable.js';
-import { $interleave, $Peekerator } from '@iter-tools/es';
+import { $interleave, $Peekerator } from 'iter-tools-es';
 import { $wrap, $unwrap, $unwrapDeep, anyType } from '../../../test/$helpers.js';
 
 const $roundRobinStrategy = $async(function* (

--- a/src/impls/$interleave/__tests__/async-interleave.auto.spec.ts
+++ b/src/impls/$interleave/__tests__/async-interleave.auto.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { AsyncIterable } from '../../../types/async-iterable.js';
-import { asyncInterleave, AsyncPeekerator } from '@iter-tools/es';
+import { asyncInterleave, AsyncPeekerator } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, asyncUnwrapDeep, anyType } from '../../../test/async-helpers.js';
 
 const asyncRoundRobinStrategy = async function* (

--- a/src/impls/$interleave/__tests__/async-interleave.test.js
+++ b/src/impls/$interleave/__tests__/async-interleave.test.js
@@ -7,7 +7,7 @@
  */
 
 import { AsyncIterable } from '../../../types/async-iterable.js';
-import { asyncInterleave, AsyncPeekerator } from '@iter-tools/es';
+import { asyncInterleave, AsyncPeekerator } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, asyncUnwrapDeep, anyType } from '../../../test/async-helpers.js';
 
 const asyncRoundRobinStrategy = async function* (

--- a/src/impls/$interleave/__tests__/interleave.auto.spec.ts
+++ b/src/impls/$interleave/__tests__/interleave.auto.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Iterable } from '../../../types/iterable.js';
-import { interleave, Peekerator } from '@iter-tools/es';
+import { interleave, Peekerator } from 'iter-tools-es';
 import { wrap, unwrap, unwrapDeep, anyType } from '../../../test/helpers.js';
 
 const roundRobinStrategy = function* (

--- a/src/impls/$interleave/__tests__/interleave.test.js
+++ b/src/impls/$interleave/__tests__/interleave.test.js
@@ -7,7 +7,7 @@
  */
 
 import { Iterable } from '../../../types/iterable.js';
-import { interleave, Peekerator } from '@iter-tools/es';
+import { interleave, Peekerator } from 'iter-tools-es';
 import { wrap, unwrap, unwrapDeep, anyType } from '../../../test/helpers.js';
 
 const roundRobinStrategy = function* (

--- a/src/impls/$interpose-seq/__tests__/$interpose-seq.test.js
+++ b/src/impls/$interpose-seq/__tests__/$interpose-seq.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $interposeSeq } from '@iter-tools/es';
+import { $interposeSeq } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`interposeSeq`, () => {

--- a/src/impls/$interpose-seq/__tests__/async-interpose-seq.auto.spec.ts
+++ b/src/impls/$interpose-seq/__tests__/async-interpose-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncInterposeSeq } from '@iter-tools/es';
+import { asyncInterposeSeq } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncInterposeSeq', () => {

--- a/src/impls/$interpose-seq/__tests__/async-interpose-seq.test.js
+++ b/src/impls/$interpose-seq/__tests__/async-interpose-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncInterposeSeq } from '@iter-tools/es';
+import { asyncInterposeSeq } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncInterposeSeq', () => {

--- a/src/impls/$interpose-seq/__tests__/interpose-seq.auto.spec.ts
+++ b/src/impls/$interpose-seq/__tests__/interpose-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { interposeSeq } from '@iter-tools/es';
+import { interposeSeq } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('interposeSeq', () => {

--- a/src/impls/$interpose-seq/__tests__/interpose-seq.test.js
+++ b/src/impls/$interpose-seq/__tests__/interpose-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { interposeSeq } from '@iter-tools/es';
+import { interposeSeq } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('interposeSeq', () => {

--- a/src/impls/$interpose/__tests__/$interpose.test.js
+++ b/src/impls/$interpose/__tests__/$interpose.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $interpose } from '@iter-tools/es';
+import { $interpose } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`interpose`, () => {

--- a/src/impls/$interpose/__tests__/async-interpose.auto.spec.ts
+++ b/src/impls/$interpose/__tests__/async-interpose.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncInterpose } from '@iter-tools/es';
+import { asyncInterpose } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncInterpose', () => {

--- a/src/impls/$interpose/__tests__/async-interpose.test.js
+++ b/src/impls/$interpose/__tests__/async-interpose.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncInterpose } from '@iter-tools/es';
+import { asyncInterpose } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncInterpose', () => {

--- a/src/impls/$interpose/__tests__/interpose.auto.spec.ts
+++ b/src/impls/$interpose/__tests__/interpose.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { interpose } from '@iter-tools/es';
+import { interpose } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('interpose', () => {

--- a/src/impls/$interpose/__tests__/interpose.test.js
+++ b/src/impls/$interpose/__tests__/interpose.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { interpose } from '@iter-tools/es';
+import { interpose } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('interpose', () => {

--- a/src/impls/$is-empty/__tests__/$is-empty.test.js
+++ b/src/impls/$is-empty/__tests__/$is-empty.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $isEmpty } from '@iter-tools/es';
+import { $isEmpty } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`isEmpty`, () => {

--- a/src/impls/$is-empty/__tests__/async-is-empty.auto.spec.ts
+++ b/src/impls/$is-empty/__tests__/async-is-empty.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIsEmpty } from '@iter-tools/es';
+import { asyncIsEmpty } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIsEmpty', () => {

--- a/src/impls/$is-empty/__tests__/async-is-empty.test.js
+++ b/src/impls/$is-empty/__tests__/async-is-empty.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIsEmpty } from '@iter-tools/es';
+import { asyncIsEmpty } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIsEmpty', () => {

--- a/src/impls/$is-empty/__tests__/is-empty.auto.spec.ts
+++ b/src/impls/$is-empty/__tests__/is-empty.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isEmpty } from '@iter-tools/es';
+import { isEmpty } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('isEmpty', () => {

--- a/src/impls/$is-empty/__tests__/is-empty.test.js
+++ b/src/impls/$is-empty/__tests__/is-empty.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isEmpty } from '@iter-tools/es';
+import { isEmpty } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('isEmpty', () => {

--- a/src/impls/$is-sorted/__tests__/$is-sorted.test.js
+++ b/src/impls/$is-sorted/__tests__/$is-sorted.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $isSorted } from '@iter-tools/es';
+import { $isSorted } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`isSorted`, () => {

--- a/src/impls/$is-sorted/__tests__/async-is-sorted.auto.spec.ts
+++ b/src/impls/$is-sorted/__tests__/async-is-sorted.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIsSorted } from '@iter-tools/es';
+import { asyncIsSorted } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIsSorted', () => {

--- a/src/impls/$is-sorted/__tests__/async-is-sorted.test.js
+++ b/src/impls/$is-sorted/__tests__/async-is-sorted.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncIsSorted } from '@iter-tools/es';
+import { asyncIsSorted } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncIsSorted', () => {

--- a/src/impls/$is-sorted/__tests__/is-sorted.auto.spec.ts
+++ b/src/impls/$is-sorted/__tests__/is-sorted.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isSorted } from '@iter-tools/es';
+import { isSorted } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('isSorted', () => {

--- a/src/impls/$is-sorted/__tests__/is-sorted.test.js
+++ b/src/impls/$is-sorted/__tests__/is-sorted.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isSorted } from '@iter-tools/es';
+import { isSorted } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('isSorted', () => {

--- a/src/impls/$join-with-seq/__tests__/$join-with-seq.test.js
+++ b/src/impls/$join-with-seq/__tests__/$join-with-seq.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $joinWithSeq } from '@iter-tools/es';
+import { $joinWithSeq } from 'iter-tools-es';
 import { $wrapDeep, $unwrap } from '../../../test/$helpers.js';
 
 describe($`joinWithSeq`, () => {

--- a/src/impls/$join-with-seq/__tests__/async-join-with-seq.auto.spec.ts
+++ b/src/impls/$join-with-seq/__tests__/async-join-with-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncJoinWithSeq } from '@iter-tools/es';
+import { asyncJoinWithSeq } from 'iter-tools-es';
 import { asyncWrapDeep, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncJoinWithSeq', () => {

--- a/src/impls/$join-with-seq/__tests__/async-join-with-seq.test.js
+++ b/src/impls/$join-with-seq/__tests__/async-join-with-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncJoinWithSeq } from '@iter-tools/es';
+import { asyncJoinWithSeq } from 'iter-tools-es';
 import { asyncWrapDeep, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncJoinWithSeq', () => {

--- a/src/impls/$join-with-seq/__tests__/join-with-seq.auto.spec.ts
+++ b/src/impls/$join-with-seq/__tests__/join-with-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { joinWithSeq } from '@iter-tools/es';
+import { joinWithSeq } from 'iter-tools-es';
 import { wrapDeep, unwrap } from '../../../test/helpers.js';
 
 describe('joinWithSeq', () => {

--- a/src/impls/$join-with-seq/__tests__/join-with-seq.test.js
+++ b/src/impls/$join-with-seq/__tests__/join-with-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { joinWithSeq } from '@iter-tools/es';
+import { joinWithSeq } from 'iter-tools-es';
 import { wrapDeep, unwrap } from '../../../test/helpers.js';
 
 describe('joinWithSeq', () => {

--- a/src/impls/$join-with/__tests__/$join-with.test.js
+++ b/src/impls/$join-with/__tests__/$join-with.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $joinWith } from '@iter-tools/es';
+import { $joinWith } from 'iter-tools-es';
 import { $wrapDeep, $unwrap } from '../../../test/$helpers.js';
 
 describe($`joinWith`, () => {

--- a/src/impls/$join-with/__tests__/async-join-with.auto.spec.ts
+++ b/src/impls/$join-with/__tests__/async-join-with.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncJoinWith } from '@iter-tools/es';
+import { asyncJoinWith } from 'iter-tools-es';
 import { asyncWrapDeep, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncJoinWith', () => {

--- a/src/impls/$join-with/__tests__/async-join-with.test.js
+++ b/src/impls/$join-with/__tests__/async-join-with.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncJoinWith } from '@iter-tools/es';
+import { asyncJoinWith } from 'iter-tools-es';
 import { asyncWrapDeep, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncJoinWith', () => {

--- a/src/impls/$join-with/__tests__/join-with.auto.spec.ts
+++ b/src/impls/$join-with/__tests__/join-with.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { joinWith } from '@iter-tools/es';
+import { joinWith } from 'iter-tools-es';
 import { wrapDeep, unwrap } from '../../../test/helpers.js';
 
 describe('joinWith', () => {

--- a/src/impls/$join-with/__tests__/join-with.test.js
+++ b/src/impls/$join-with/__tests__/join-with.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { joinWith } from '@iter-tools/es';
+import { joinWith } from 'iter-tools-es';
 import { wrapDeep, unwrap } from '../../../test/helpers.js';
 
 describe('joinWith', () => {

--- a/src/impls/$join/__tests__/$join.test.js
+++ b/src/impls/$join/__tests__/$join.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $join } from '@iter-tools/es';
+import { $join } from 'iter-tools-es';
 import { $wrapDeep, $unwrap } from '../../../test/$helpers.js';
 
 describe($`join`, () => {

--- a/src/impls/$join/__tests__/async-join.auto.spec.ts
+++ b/src/impls/$join/__tests__/async-join.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncJoin } from '@iter-tools/es';
+import { asyncJoin } from 'iter-tools-es';
 import { asyncWrapDeep, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncJoin', () => {

--- a/src/impls/$join/__tests__/async-join.test.js
+++ b/src/impls/$join/__tests__/async-join.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncJoin } from '@iter-tools/es';
+import { asyncJoin } from 'iter-tools-es';
 import { asyncWrapDeep, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncJoin', () => {

--- a/src/impls/$join/__tests__/join.auto.spec.ts
+++ b/src/impls/$join/__tests__/join.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { join } from '@iter-tools/es';
+import { join } from 'iter-tools-es';
 import { wrapDeep, unwrap } from '../../../test/helpers.js';
 
 describe('join', () => {

--- a/src/impls/$join/__tests__/join.test.js
+++ b/src/impls/$join/__tests__/join.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { join } from '@iter-tools/es';
+import { join } from 'iter-tools-es';
 import { wrapDeep, unwrap } from '../../../test/helpers.js';
 
 describe('join', () => {

--- a/src/impls/$leading-window/__tests__/$leading-window.test.js
+++ b/src/impls/$leading-window/__tests__/$leading-window.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $leadingWindow } from '@iter-tools/es';
+import { $leadingWindow } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`leadingWindow`, () => {

--- a/src/impls/$leading-window/__tests__/async-leading-window.auto.spec.ts
+++ b/src/impls/$leading-window/__tests__/async-leading-window.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncLeadingWindow } from '@iter-tools/es';
+import { asyncLeadingWindow } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncLeadingWindow', () => {

--- a/src/impls/$leading-window/__tests__/async-leading-window.test.js
+++ b/src/impls/$leading-window/__tests__/async-leading-window.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncLeadingWindow } from '@iter-tools/es';
+import { asyncLeadingWindow } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncLeadingWindow', () => {

--- a/src/impls/$leading-window/__tests__/leading-window.auto.spec.ts
+++ b/src/impls/$leading-window/__tests__/leading-window.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { leadingWindow } from '@iter-tools/es';
+import { leadingWindow } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('leadingWindow', () => {

--- a/src/impls/$leading-window/__tests__/leading-window.test.js
+++ b/src/impls/$leading-window/__tests__/leading-window.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { leadingWindow } from '@iter-tools/es';
+import { leadingWindow } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('leadingWindow', () => {

--- a/src/impls/$map/__tests__/$map.test.js
+++ b/src/impls/$map/__tests__/$map.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $map } from '@iter-tools/es';
+import { $map } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`map`, () => {

--- a/src/impls/$map/__tests__/async-map-parallel.auto.spec.ts
+++ b/src/impls/$map/__tests__/async-map-parallel.auto.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { delay } from '../../../internal/delay.js';
-import { asyncMapParallel } from '@iter-tools/es';
+import { asyncMapParallel } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncMapParallel', () => {

--- a/src/impls/$map/__tests__/async-map-parallel.test.js
+++ b/src/impls/$map/__tests__/async-map-parallel.test.js
@@ -1,5 +1,5 @@
 import { delay } from '../../../internal/delay.js';
-import { asyncMapParallel } from '@iter-tools/es';
+import { asyncMapParallel } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncMapParallel', () => {

--- a/src/impls/$map/__tests__/async-map.auto.spec.ts
+++ b/src/impls/$map/__tests__/async-map.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncMap } from '@iter-tools/es';
+import { asyncMap } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncMap', () => {

--- a/src/impls/$map/__tests__/async-map.test.js
+++ b/src/impls/$map/__tests__/async-map.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncMap } from '@iter-tools/es';
+import { asyncMap } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncMap', () => {

--- a/src/impls/$map/__tests__/map.auto.spec.ts
+++ b/src/impls/$map/__tests__/map.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { map } from '@iter-tools/es';
+import { map } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('map', () => {

--- a/src/impls/$map/__tests__/map.test.js
+++ b/src/impls/$map/__tests__/map.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { map } from '@iter-tools/es';
+import { map } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('map', () => {

--- a/src/impls/$peekerate/__tests__/$peekerate.test.js
+++ b/src/impls/$peekerate/__tests__/$peekerate.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $peekerate } from '@iter-tools/es';
+import { $peekerate } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`peekerate`, () => {

--- a/src/impls/$peekerate/__tests__/async-peekerate.auto.spec.ts
+++ b/src/impls/$peekerate/__tests__/async-peekerate.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncPeekerate } from '@iter-tools/es';
+import { asyncPeekerate } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncPeekerate', () => {

--- a/src/impls/$peekerate/__tests__/async-peekerate.test.js
+++ b/src/impls/$peekerate/__tests__/async-peekerate.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncPeekerate } from '@iter-tools/es';
+import { asyncPeekerate } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncPeekerate', () => {

--- a/src/impls/$peekerate/__tests__/peekerate.auto.spec.ts
+++ b/src/impls/$peekerate/__tests__/peekerate.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { peekerate } from '@iter-tools/es';
+import { peekerate } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('peekerate', () => {

--- a/src/impls/$peekerate/__tests__/peekerate.test.js
+++ b/src/impls/$peekerate/__tests__/peekerate.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { peekerate } from '@iter-tools/es';
+import { peekerate } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('peekerate', () => {

--- a/src/impls/$prepend/__tests__/$prepend.test.js
+++ b/src/impls/$prepend/__tests__/$prepend.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $prepend, $toArray, $wrap } from '@iter-tools/es';
+import { $prepend, $toArray, $wrap } from 'iter-tools-es';
 
 describe($`prepend`, () => {
   describe('when source is empty', () => {

--- a/src/impls/$prepend/__tests__/async-prepend.auto.spec.ts
+++ b/src/impls/$prepend/__tests__/async-prepend.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncPrepend, asyncToArray, asyncWrap } from '@iter-tools/es';
+import { asyncPrepend, asyncToArray, asyncWrap } from 'iter-tools-es';
 
 describe('asyncPrepend', () => {
   describe('when source is empty', () => {

--- a/src/impls/$prepend/__tests__/async-prepend.test.js
+++ b/src/impls/$prepend/__tests__/async-prepend.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncPrepend, asyncToArray, asyncWrap } from '@iter-tools/es';
+import { asyncPrepend, asyncToArray, asyncWrap } from 'iter-tools-es';
 
 describe('asyncPrepend', () => {
   describe('when source is empty', () => {

--- a/src/impls/$prepend/__tests__/prepend.auto.spec.ts
+++ b/src/impls/$prepend/__tests__/prepend.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { prepend, toArray, wrap } from '@iter-tools/es';
+import { prepend, toArray, wrap } from 'iter-tools-es';
 
 describe('prepend', () => {
   describe('when source is empty', () => {

--- a/src/impls/$prepend/__tests__/prepend.test.js
+++ b/src/impls/$prepend/__tests__/prepend.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { prepend, toArray, wrap } from '@iter-tools/es';
+import { prepend, toArray, wrap } from 'iter-tools-es';
 
 describe('prepend', () => {
   describe('when source is empty', () => {

--- a/src/impls/$reduce/__tests__/$reduce.test.js
+++ b/src/impls/$reduce/__tests__/$reduce.test.js
@@ -1,7 +1,7 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 import { $awaitError } from '../../../../generate/test.macro.cjs';
 
-import { $reduce } from '@iter-tools/es';
+import { $reduce } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`reduce`, () => {

--- a/src/impls/$reduce/__tests__/async-reduce.auto.spec.ts
+++ b/src/impls/$reduce/__tests__/async-reduce.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncReduce } from '@iter-tools/es';
+import { asyncReduce } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncReduce', () => {

--- a/src/impls/$reduce/__tests__/async-reduce.test.js
+++ b/src/impls/$reduce/__tests__/async-reduce.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncReduce } from '@iter-tools/es';
+import { asyncReduce } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncReduce', () => {

--- a/src/impls/$reduce/__tests__/reduce.auto.spec.ts
+++ b/src/impls/$reduce/__tests__/reduce.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { reduce } from '@iter-tools/es';
+import { reduce } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('reduce', () => {

--- a/src/impls/$reduce/__tests__/reduce.test.js
+++ b/src/impls/$reduce/__tests__/reduce.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { reduce } from '@iter-tools/es';
+import { reduce } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('reduce', () => {

--- a/src/impls/$reverse/__tests__/$reverse.test.js
+++ b/src/impls/$reverse/__tests__/$reverse.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $reverse } from '@iter-tools/es';
+import { $reverse } from 'iter-tools-es';
 import { $unwrap, $wrap } from '../../../test/$helpers.js';
 
 describe($`reverse`, () => {

--- a/src/impls/$reverse/__tests__/async-reverse.auto.spec.ts
+++ b/src/impls/$reverse/__tests__/async-reverse.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncReverse } from '@iter-tools/es';
+import { asyncReverse } from 'iter-tools-es';
 import { asyncUnwrap, asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncReverse', () => {

--- a/src/impls/$reverse/__tests__/async-reverse.test.js
+++ b/src/impls/$reverse/__tests__/async-reverse.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncReverse } from '@iter-tools/es';
+import { asyncReverse } from 'iter-tools-es';
 import { asyncUnwrap, asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncReverse', () => {

--- a/src/impls/$reverse/__tests__/reverse.auto.spec.ts
+++ b/src/impls/$reverse/__tests__/reverse.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { reverse } from '@iter-tools/es';
+import { reverse } from 'iter-tools-es';
 import { unwrap, wrap } from '../../../test/helpers.js';
 
 describe('reverse', () => {

--- a/src/impls/$reverse/__tests__/reverse.test.js
+++ b/src/impls/$reverse/__tests__/reverse.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { reverse } from '@iter-tools/es';
+import { reverse } from 'iter-tools-es';
 import { unwrap, wrap } from '../../../test/helpers.js';
 
 describe('reverse', () => {

--- a/src/impls/$round-robin/__tests__/$round-robin.test.js
+++ b/src/impls/$round-robin/__tests__/$round-robin.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $roundRobin } from '@iter-tools/es';
+import { $roundRobin } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`roundRobin`, () => {

--- a/src/impls/$round-robin/__tests__/async-round-robin.auto.spec.ts
+++ b/src/impls/$round-robin/__tests__/async-round-robin.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncRoundRobin } from '@iter-tools/es';
+import { asyncRoundRobin } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncRoundRobin', () => {

--- a/src/impls/$round-robin/__tests__/async-round-robin.test.js
+++ b/src/impls/$round-robin/__tests__/async-round-robin.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncRoundRobin } from '@iter-tools/es';
+import { asyncRoundRobin } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncRoundRobin', () => {

--- a/src/impls/$round-robin/__tests__/round-robin.auto.spec.ts
+++ b/src/impls/$round-robin/__tests__/round-robin.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { roundRobin } from '@iter-tools/es';
+import { roundRobin } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('roundRobin', () => {

--- a/src/impls/$round-robin/__tests__/round-robin.test.js
+++ b/src/impls/$round-robin/__tests__/round-robin.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { roundRobin } from '@iter-tools/es';
+import { roundRobin } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('roundRobin', () => {

--- a/src/impls/$size/__tests__/$size.spec.ts
+++ b/src/impls/$size/__tests__/$size.spec.ts
@@ -1,6 +1,6 @@
 import { $Promise } from '../../../../generate/async.macro.cjs';
 import assert from 'static-type-assert';
-import { $size } from '@iter-tools/es';
+import { $size } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$size/__tests__/$size.test.js
+++ b/src/impls/$size/__tests__/$size.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $size } from '@iter-tools/es';
+import { $size } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`size`, () => {

--- a/src/impls/$size/__tests__/async-size.auto.spec.ts
+++ b/src/impls/$size/__tests__/async-size.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSize } from '@iter-tools/es';
+import { asyncSize } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncSize', () => {

--- a/src/impls/$size/__tests__/async-size.spec.ts
+++ b/src/impls/$size/__tests__/async-size.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import assert from 'static-type-assert';
-import { asyncSize } from '@iter-tools/es';
+import { asyncSize } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$size/__tests__/async-size.test.js
+++ b/src/impls/$size/__tests__/async-size.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSize } from '@iter-tools/es';
+import { asyncSize } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncSize', () => {

--- a/src/impls/$size/__tests__/size.auto.spec.ts
+++ b/src/impls/$size/__tests__/size.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { size } from '@iter-tools/es';
+import { size } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('size', () => {

--- a/src/impls/$size/__tests__/size.spec.ts
+++ b/src/impls/$size/__tests__/size.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import assert from 'static-type-assert';
-import { size } from '@iter-tools/es';
+import { size } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$size/__tests__/size.test.js
+++ b/src/impls/$size/__tests__/size.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { size } from '@iter-tools/es';
+import { size } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('size', () => {

--- a/src/impls/$slice/__tests__/$slice.test.js
+++ b/src/impls/$slice/__tests__/$slice.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $slice } from '@iter-tools/es';
+import { $slice } from 'iter-tools-es';
 import { $Iterable } from '../../../types/$iterable.js';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 

--- a/src/impls/$slice/__tests__/async-slice.auto.spec.ts
+++ b/src/impls/$slice/__tests__/async-slice.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSlice } from '@iter-tools/es';
+import { asyncSlice } from 'iter-tools-es';
 import { AsyncIterable } from '../../../types/async-iterable.js';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 

--- a/src/impls/$slice/__tests__/async-slice.test.js
+++ b/src/impls/$slice/__tests__/async-slice.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSlice } from '@iter-tools/es';
+import { asyncSlice } from 'iter-tools-es';
 import { AsyncIterable } from '../../../types/async-iterable.js';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 

--- a/src/impls/$slice/__tests__/slice.auto.spec.ts
+++ b/src/impls/$slice/__tests__/slice.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { slice } from '@iter-tools/es';
+import { slice } from 'iter-tools-es';
 import { Iterable } from '../../../types/iterable.js';
 import { wrap, unwrap } from '../../../test/helpers.js';
 

--- a/src/impls/$slice/__tests__/slice.test.js
+++ b/src/impls/$slice/__tests__/slice.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { slice } from '@iter-tools/es';
+import { slice } from 'iter-tools-es';
 import { Iterable } from '../../../types/iterable.js';
 import { wrap, unwrap } from '../../../test/helpers.js';
 

--- a/src/impls/$some/__tests__/$some.test.js
+++ b/src/impls/$some/__tests__/$some.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $some } from '@iter-tools/es';
+import { $some } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`some`, () => {

--- a/src/impls/$some/__tests__/async-some.auto.spec.ts
+++ b/src/impls/$some/__tests__/async-some.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSome } from '@iter-tools/es';
+import { asyncSome } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncSome', () => {

--- a/src/impls/$some/__tests__/async-some.test.js
+++ b/src/impls/$some/__tests__/async-some.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSome } from '@iter-tools/es';
+import { asyncSome } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncSome', () => {

--- a/src/impls/$some/__tests__/some.auto.spec.ts
+++ b/src/impls/$some/__tests__/some.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { some } from '@iter-tools/es';
+import { some } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('some', () => {

--- a/src/impls/$some/__tests__/some.test.js
+++ b/src/impls/$some/__tests__/some.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { some } from '@iter-tools/es';
+import { some } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('some', () => {

--- a/src/impls/$split-at/__tests__/$split-at.spec.ts
+++ b/src/impls/$split-at/__tests__/$split-at.spec.ts
@@ -2,7 +2,7 @@ import assert from 'static-type-assert';
 
 import { ResultIterable as SyncResultIterable } from '../../../types/iterable';
 import { $Iterable, $ResultIterable } from '../../../types/$iterable';
-import { $splitAt } from '@iter-tools/es';
+import { $splitAt } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$split-at/__tests__/$split-at.test.js
+++ b/src/impls/$split-at/__tests__/$split-at.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $splitAt } from '@iter-tools/es';
+import { $splitAt } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`splitAt`, () => {

--- a/src/impls/$split-at/__tests__/async-split-at.auto.spec.ts
+++ b/src/impls/$split-at/__tests__/async-split-at.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitAt } from '@iter-tools/es';
+import { asyncSplitAt } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitAt', () => {

--- a/src/impls/$split-at/__tests__/async-split-at.spec.ts
+++ b/src/impls/$split-at/__tests__/async-split-at.spec.ts
@@ -10,7 +10,7 @@ import assert from 'static-type-assert';
 
 import { ResultIterable as SyncResultIterable } from '../../../types/iterable';
 import { AsyncIterable, AsyncResultIterable } from '../../../types/async-iterable';
-import { asyncSplitAt } from '@iter-tools/es';
+import { asyncSplitAt } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$split-at/__tests__/async-split-at.test.js
+++ b/src/impls/$split-at/__tests__/async-split-at.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitAt } from '@iter-tools/es';
+import { asyncSplitAt } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitAt', () => {

--- a/src/impls/$split-at/__tests__/split-at.auto.spec.ts
+++ b/src/impls/$split-at/__tests__/split-at.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitAt } from '@iter-tools/es';
+import { splitAt } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitAt', () => {

--- a/src/impls/$split-at/__tests__/split-at.spec.ts
+++ b/src/impls/$split-at/__tests__/split-at.spec.ts
@@ -13,7 +13,7 @@ import {
   Iterable,
   ResultIterable,
 } from '../../../types/iterable';
-import { splitAt } from '@iter-tools/es';
+import { splitAt } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/$split-at/__tests__/split-at.test.js
+++ b/src/impls/$split-at/__tests__/split-at.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitAt } from '@iter-tools/es';
+import { splitAt } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitAt', () => {

--- a/src/impls/$split-on-any-seq/__tests__/$split-on-any-seq.test.js
+++ b/src/impls/$split-on-any-seq/__tests__/$split-on-any-seq.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $splitOnAnySeq, $toArray } from '@iter-tools/es';
+import { $splitOnAnySeq, $toArray } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`splitOnAnySeq`, () => {

--- a/src/impls/$split-on-any-seq/__tests__/async-split-on-any-seq.auto.spec.ts
+++ b/src/impls/$split-on-any-seq/__tests__/async-split-on-any-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitOnAnySeq, asyncToArray } from '@iter-tools/es';
+import { asyncSplitOnAnySeq, asyncToArray } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitOnAnySeq', () => {

--- a/src/impls/$split-on-any-seq/__tests__/async-split-on-any-seq.test.js
+++ b/src/impls/$split-on-any-seq/__tests__/async-split-on-any-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitOnAnySeq, asyncToArray } from '@iter-tools/es';
+import { asyncSplitOnAnySeq, asyncToArray } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitOnAnySeq', () => {

--- a/src/impls/$split-on-any-seq/__tests__/split-on-any-seq.auto.spec.ts
+++ b/src/impls/$split-on-any-seq/__tests__/split-on-any-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitOnAnySeq, toArray } from '@iter-tools/es';
+import { splitOnAnySeq, toArray } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitOnAnySeq', () => {

--- a/src/impls/$split-on-any-seq/__tests__/split-on-any-seq.test.js
+++ b/src/impls/$split-on-any-seq/__tests__/split-on-any-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitOnAnySeq, toArray } from '@iter-tools/es';
+import { splitOnAnySeq, toArray } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitOnAnySeq', () => {

--- a/src/impls/$split-on-any/__tests__/$split-on-any.test.js
+++ b/src/impls/$split-on-any/__tests__/$split-on-any.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $splitOnAny } from '@iter-tools/es';
+import { $splitOnAny } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`splitOnAny`, () => {

--- a/src/impls/$split-on-any/__tests__/async-split-on-any.auto.spec.ts
+++ b/src/impls/$split-on-any/__tests__/async-split-on-any.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitOnAny } from '@iter-tools/es';
+import { asyncSplitOnAny } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitOnAny', () => {

--- a/src/impls/$split-on-any/__tests__/async-split-on-any.test.js
+++ b/src/impls/$split-on-any/__tests__/async-split-on-any.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitOnAny } from '@iter-tools/es';
+import { asyncSplitOnAny } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitOnAny', () => {

--- a/src/impls/$split-on-any/__tests__/split-on-any.auto.spec.ts
+++ b/src/impls/$split-on-any/__tests__/split-on-any.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitOnAny } from '@iter-tools/es';
+import { splitOnAny } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitOnAny', () => {

--- a/src/impls/$split-on-any/__tests__/split-on-any.test.js
+++ b/src/impls/$split-on-any/__tests__/split-on-any.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitOnAny } from '@iter-tools/es';
+import { splitOnAny } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitOnAny', () => {

--- a/src/impls/$split-on-seq/__tests__/$split-on-seq.test.js
+++ b/src/impls/$split-on-seq/__tests__/$split-on-seq.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $splitOnSeq, $toArray } from '@iter-tools/es';
+import { $splitOnSeq, $toArray } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`splitOnSeq`, () => {

--- a/src/impls/$split-on-seq/__tests__/async-split-on-seq.auto.spec.ts
+++ b/src/impls/$split-on-seq/__tests__/async-split-on-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitOnSeq, asyncToArray } from '@iter-tools/es';
+import { asyncSplitOnSeq, asyncToArray } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitOnSeq', () => {

--- a/src/impls/$split-on-seq/__tests__/async-split-on-seq.test.js
+++ b/src/impls/$split-on-seq/__tests__/async-split-on-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitOnSeq, asyncToArray } from '@iter-tools/es';
+import { asyncSplitOnSeq, asyncToArray } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitOnSeq', () => {

--- a/src/impls/$split-on-seq/__tests__/split-on-seq.auto.spec.ts
+++ b/src/impls/$split-on-seq/__tests__/split-on-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitOnSeq, toArray } from '@iter-tools/es';
+import { splitOnSeq, toArray } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitOnSeq', () => {

--- a/src/impls/$split-on-seq/__tests__/split-on-seq.test.js
+++ b/src/impls/$split-on-seq/__tests__/split-on-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitOnSeq, toArray } from '@iter-tools/es';
+import { splitOnSeq, toArray } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitOnSeq', () => {

--- a/src/impls/$split-on/__tests__/$split-on.test.js
+++ b/src/impls/$split-on/__tests__/$split-on.test.js
@@ -1,7 +1,7 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 import { $awaitError } from '../../../../generate/test.macro.cjs';
 
-import { $splitOn } from '@iter-tools/es';
+import { $splitOn } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`splitOn`, () => {

--- a/src/impls/$split-on/__tests__/async-split-on.auto.spec.ts
+++ b/src/impls/$split-on/__tests__/async-split-on.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitOn } from '@iter-tools/es';
+import { asyncSplitOn } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitOn', () => {

--- a/src/impls/$split-on/__tests__/async-split-on.test.js
+++ b/src/impls/$split-on/__tests__/async-split-on.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitOn } from '@iter-tools/es';
+import { asyncSplitOn } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitOn', () => {

--- a/src/impls/$split-on/__tests__/split-on.auto.spec.ts
+++ b/src/impls/$split-on/__tests__/split-on.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitOn } from '@iter-tools/es';
+import { splitOn } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitOn', () => {

--- a/src/impls/$split-on/__tests__/split-on.test.js
+++ b/src/impls/$split-on/__tests__/split-on.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitOn } from '@iter-tools/es';
+import { splitOn } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitOn', () => {

--- a/src/impls/$split-when/__tests__/$split-when.test.js
+++ b/src/impls/$split-when/__tests__/$split-when.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $splitWhen } from '@iter-tools/es';
+import { $splitWhen } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`splitWhen`, () => {

--- a/src/impls/$split-when/__tests__/async-split-when.auto.spec.ts
+++ b/src/impls/$split-when/__tests__/async-split-when.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitWhen } from '@iter-tools/es';
+import { asyncSplitWhen } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitWhen', () => {

--- a/src/impls/$split-when/__tests__/async-split-when.test.js
+++ b/src/impls/$split-when/__tests__/async-split-when.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitWhen } from '@iter-tools/es';
+import { asyncSplitWhen } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitWhen', () => {

--- a/src/impls/$split-when/__tests__/split-when.auto.spec.ts
+++ b/src/impls/$split-when/__tests__/split-when.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitWhen } from '@iter-tools/es';
+import { splitWhen } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitWhen', () => {

--- a/src/impls/$split-when/__tests__/split-when.test.js
+++ b/src/impls/$split-when/__tests__/split-when.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitWhen } from '@iter-tools/es';
+import { splitWhen } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitWhen', () => {

--- a/src/impls/$split-with/__tests__/$split-with.test.js
+++ b/src/impls/$split-with/__tests__/$split-with.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $splitWith } from '@iter-tools/es';
+import { $splitWith } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`splitWith`, () => {

--- a/src/impls/$split-with/__tests__/async-split-with.auto.spec.ts
+++ b/src/impls/$split-with/__tests__/async-split-with.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitWith } from '@iter-tools/es';
+import { asyncSplitWith } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitWith', () => {

--- a/src/impls/$split-with/__tests__/async-split-with.test.js
+++ b/src/impls/$split-with/__tests__/async-split-with.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplitWith } from '@iter-tools/es';
+import { asyncSplitWith } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplitWith', () => {

--- a/src/impls/$split-with/__tests__/split-with.auto.spec.ts
+++ b/src/impls/$split-with/__tests__/split-with.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitWith } from '@iter-tools/es';
+import { splitWith } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitWith', () => {

--- a/src/impls/$split-with/__tests__/split-with.test.js
+++ b/src/impls/$split-with/__tests__/split-with.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { splitWith } from '@iter-tools/es';
+import { splitWith } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('splitWith', () => {

--- a/src/impls/$split/__tests__/$split.test.js
+++ b/src/impls/$split/__tests__/$split.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $split } from '@iter-tools/es';
+import { $split } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`split`, () => {

--- a/src/impls/$split/__tests__/async-split.auto.spec.ts
+++ b/src/impls/$split/__tests__/async-split.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplit } from '@iter-tools/es';
+import { asyncSplit } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplit', () => {

--- a/src/impls/$split/__tests__/async-split.test.js
+++ b/src/impls/$split/__tests__/async-split.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSplit } from '@iter-tools/es';
+import { asyncSplit } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncSplit', () => {

--- a/src/impls/$split/__tests__/split.auto.spec.ts
+++ b/src/impls/$split/__tests__/split.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { split } from '@iter-tools/es';
+import { split } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('split', () => {

--- a/src/impls/$split/__tests__/split.test.js
+++ b/src/impls/$split/__tests__/split.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { split } from '@iter-tools/es';
+import { split } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('split', () => {

--- a/src/impls/$spliterate-grouped/__tests__/$spliterate-grouped.test.js
+++ b/src/impls/$spliterate-grouped/__tests__/$spliterate-grouped.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $spliterateGrouped } from '@iter-tools/es';
+import { $spliterateGrouped } from 'iter-tools-es';
 import { $unwrapDeep } from '../../../test/$helpers.js';
 
 $async;

--- a/src/impls/$spliterate-grouped/__tests__/async-spliterate-grouped.auto.spec.ts
+++ b/src/impls/$spliterate-grouped/__tests__/async-spliterate-grouped.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSpliterateGrouped } from '@iter-tools/es';
+import { asyncSpliterateGrouped } from 'iter-tools-es';
 import { asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 async function* asyncIdentityStrategy(_split: any, _options: any, source: any) {

--- a/src/impls/$spliterate-grouped/__tests__/async-spliterate-grouped.test.js
+++ b/src/impls/$spliterate-grouped/__tests__/async-spliterate-grouped.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSpliterateGrouped } from '@iter-tools/es';
+import { asyncSpliterateGrouped } from 'iter-tools-es';
 import { asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 async function* asyncIdentityStrategy(_split: any, _options: any, source: any) {

--- a/src/impls/$spliterate-grouped/__tests__/spliterate-grouped.auto.spec.ts
+++ b/src/impls/$spliterate-grouped/__tests__/spliterate-grouped.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { spliterateGrouped } from '@iter-tools/es';
+import { spliterateGrouped } from 'iter-tools-es';
 import { unwrapDeep } from '../../../test/helpers.js';
 
 function* identityStrategy(_split: any, _options: any, source: any) {

--- a/src/impls/$spliterate-grouped/__tests__/spliterate-grouped.test.js
+++ b/src/impls/$spliterate-grouped/__tests__/spliterate-grouped.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { spliterateGrouped } from '@iter-tools/es';
+import { spliterateGrouped } from 'iter-tools-es';
 import { unwrapDeep } from '../../../test/helpers.js';
 
 function* identityStrategy(_split: any, _options: any, source: any) {

--- a/src/impls/$spliterate/__tests__/$spliterate.test.js
+++ b/src/impls/$spliterate/__tests__/$spliterate.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $spliterate } from '@iter-tools/es';
+import { $spliterate } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 $async;

--- a/src/impls/$spliterate/__tests__/async-spliterate.auto.spec.ts
+++ b/src/impls/$spliterate/__tests__/async-spliterate.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSpliterate } from '@iter-tools/es';
+import { asyncSpliterate } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 async function* asyncIdentityStrategy(_split: any, _options: any, source: any) {

--- a/src/impls/$spliterate/__tests__/async-spliterate.test.js
+++ b/src/impls/$spliterate/__tests__/async-spliterate.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncSpliterate } from '@iter-tools/es';
+import { asyncSpliterate } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 async function* asyncIdentityStrategy(_split: any, _options: any, source: any) {

--- a/src/impls/$spliterate/__tests__/spliterate.auto.spec.ts
+++ b/src/impls/$spliterate/__tests__/spliterate.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { spliterate } from '@iter-tools/es';
+import { spliterate } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 function* identityStrategy(_split: any, _options: any, source: any) {

--- a/src/impls/$spliterate/__tests__/spliterate.test.js
+++ b/src/impls/$spliterate/__tests__/spliterate.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { spliterate } from '@iter-tools/es';
+import { spliterate } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 function* identityStrategy(_split: any, _options: any, source: any) {

--- a/src/impls/$starts-with-any-seq/__tests__/$starts-with-any-seq.test.js
+++ b/src/impls/$starts-with-any-seq/__tests__/$starts-with-any-seq.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $startsWithAnySeq } from '@iter-tools/es';
+import { $startsWithAnySeq } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`startsWithAnySeq`, () => {

--- a/src/impls/$starts-with-any-seq/__tests__/async-starts-with-any-seq.auto.spec.ts
+++ b/src/impls/$starts-with-any-seq/__tests__/async-starts-with-any-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStartsWithAnySeq } from '@iter-tools/es';
+import { asyncStartsWithAnySeq } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStartsWithAnySeq', () => {

--- a/src/impls/$starts-with-any-seq/__tests__/async-starts-with-any-seq.test.js
+++ b/src/impls/$starts-with-any-seq/__tests__/async-starts-with-any-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStartsWithAnySeq } from '@iter-tools/es';
+import { asyncStartsWithAnySeq } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStartsWithAnySeq', () => {

--- a/src/impls/$starts-with-any-seq/__tests__/starts-with-any-seq.auto.spec.ts
+++ b/src/impls/$starts-with-any-seq/__tests__/starts-with-any-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { startsWithAnySeq } from '@iter-tools/es';
+import { startsWithAnySeq } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('startsWithAnySeq', () => {

--- a/src/impls/$starts-with-any-seq/__tests__/starts-with-any-seq.test.js
+++ b/src/impls/$starts-with-any-seq/__tests__/starts-with-any-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { startsWithAnySeq } from '@iter-tools/es';
+import { startsWithAnySeq } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('startsWithAnySeq', () => {

--- a/src/impls/$starts-with-any/__tests__/$starts-with-any.test.js
+++ b/src/impls/$starts-with-any/__tests__/$starts-with-any.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $startsWithAny } from '@iter-tools/es';
+import { $startsWithAny } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`startsWithAny`, () => {

--- a/src/impls/$starts-with-any/__tests__/async-starts-with-any.auto.spec.ts
+++ b/src/impls/$starts-with-any/__tests__/async-starts-with-any.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStartsWithAny } from '@iter-tools/es';
+import { asyncStartsWithAny } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStartsWithAny', () => {

--- a/src/impls/$starts-with-any/__tests__/async-starts-with-any.test.js
+++ b/src/impls/$starts-with-any/__tests__/async-starts-with-any.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStartsWithAny } from '@iter-tools/es';
+import { asyncStartsWithAny } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStartsWithAny', () => {

--- a/src/impls/$starts-with-any/__tests__/starts-with-any.auto.spec.ts
+++ b/src/impls/$starts-with-any/__tests__/starts-with-any.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { startsWithAny } from '@iter-tools/es';
+import { startsWithAny } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('startsWithAny', () => {

--- a/src/impls/$starts-with-any/__tests__/starts-with-any.test.js
+++ b/src/impls/$starts-with-any/__tests__/starts-with-any.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { startsWithAny } from '@iter-tools/es';
+import { startsWithAny } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('startsWithAny', () => {

--- a/src/impls/$starts-with-seq/__tests__/$starts-with-seq.test.js
+++ b/src/impls/$starts-with-seq/__tests__/$starts-with-seq.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $startsWithSeq } from '@iter-tools/es';
+import { $startsWithSeq } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`startsWithSeq`, () => {

--- a/src/impls/$starts-with-seq/__tests__/async-starts-with-seq.auto.spec.ts
+++ b/src/impls/$starts-with-seq/__tests__/async-starts-with-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStartsWithSeq } from '@iter-tools/es';
+import { asyncStartsWithSeq } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStartsWithSeq', () => {

--- a/src/impls/$starts-with-seq/__tests__/async-starts-with-seq.test.js
+++ b/src/impls/$starts-with-seq/__tests__/async-starts-with-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStartsWithSeq } from '@iter-tools/es';
+import { asyncStartsWithSeq } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStartsWithSeq', () => {

--- a/src/impls/$starts-with-seq/__tests__/starts-with-seq.auto.spec.ts
+++ b/src/impls/$starts-with-seq/__tests__/starts-with-seq.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { startsWithSeq } from '@iter-tools/es';
+import { startsWithSeq } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('startsWithSeq', () => {

--- a/src/impls/$starts-with-seq/__tests__/starts-with-seq.test.js
+++ b/src/impls/$starts-with-seq/__tests__/starts-with-seq.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { startsWithSeq } from '@iter-tools/es';
+import { startsWithSeq } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('startsWithSeq', () => {

--- a/src/impls/$starts-with/__tests__/$starts-with.test.js
+++ b/src/impls/$starts-with/__tests__/$starts-with.test.js
@@ -1,6 +1,6 @@
 import { $, $isSync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $startsWith } from '@iter-tools/es';
+import { $startsWith } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`startsWith`, () => {

--- a/src/impls/$starts-with/__tests__/async-starts-with.auto.spec.ts
+++ b/src/impls/$starts-with/__tests__/async-starts-with.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStartsWith } from '@iter-tools/es';
+import { asyncStartsWith } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStartsWith', () => {

--- a/src/impls/$starts-with/__tests__/async-starts-with.test.js
+++ b/src/impls/$starts-with/__tests__/async-starts-with.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStartsWith } from '@iter-tools/es';
+import { asyncStartsWith } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStartsWith', () => {

--- a/src/impls/$starts-with/__tests__/starts-with.auto.spec.ts
+++ b/src/impls/$starts-with/__tests__/starts-with.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { startsWith } from '@iter-tools/es';
+import { startsWith } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('startsWith', () => {

--- a/src/impls/$starts-with/__tests__/starts-with.test.js
+++ b/src/impls/$starts-with/__tests__/starts-with.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { startsWith } from '@iter-tools/es';
+import { startsWith } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('startsWith', () => {

--- a/src/impls/$str/__tests__/$str.test.js
+++ b/src/impls/$str/__tests__/$str.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $str } from '@iter-tools/es';
+import { $str } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`str`, () => {

--- a/src/impls/$str/__tests__/async-str.auto.spec.ts
+++ b/src/impls/$str/__tests__/async-str.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStr } from '@iter-tools/es';
+import { asyncStr } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStr', () => {

--- a/src/impls/$str/__tests__/async-str.test.js
+++ b/src/impls/$str/__tests__/async-str.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncStr } from '@iter-tools/es';
+import { asyncStr } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncStr', () => {

--- a/src/impls/$str/__tests__/str.auto.spec.ts
+++ b/src/impls/$str/__tests__/str.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { str } from '@iter-tools/es';
+import { str } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('str', () => {

--- a/src/impls/$str/__tests__/str.test.js
+++ b/src/impls/$str/__tests__/str.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { str } from '@iter-tools/es';
+import { str } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('str', () => {

--- a/src/impls/$take-last-or/__tests__/$take-last-or.test.js
+++ b/src/impls/$take-last-or/__tests__/$take-last-or.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $takeLastOr } from '@iter-tools/es';
+import { $takeLastOr } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`takeLastOr`, () => {

--- a/src/impls/$take-last-or/__tests__/async-take-last-or.auto.spec.ts
+++ b/src/impls/$take-last-or/__tests__/async-take-last-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTakeLastOr } from '@iter-tools/es';
+import { asyncTakeLastOr } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncTakeLastOr', () => {

--- a/src/impls/$take-last-or/__tests__/async-take-last-or.test.js
+++ b/src/impls/$take-last-or/__tests__/async-take-last-or.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTakeLastOr } from '@iter-tools/es';
+import { asyncTakeLastOr } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncTakeLastOr', () => {

--- a/src/impls/$take-last-or/__tests__/take-last-or.auto.spec.ts
+++ b/src/impls/$take-last-or/__tests__/take-last-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { takeLastOr } from '@iter-tools/es';
+import { takeLastOr } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('takeLastOr', () => {

--- a/src/impls/$take-last-or/__tests__/take-last-or.test.js
+++ b/src/impls/$take-last-or/__tests__/take-last-or.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { takeLastOr } from '@iter-tools/es';
+import { takeLastOr } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('takeLastOr', () => {

--- a/src/impls/$take-last/__tests__/$take-last.test.js
+++ b/src/impls/$take-last/__tests__/$take-last.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $takeLast } from '@iter-tools/es';
+import { $takeLast } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`takeLast`, () => {

--- a/src/impls/$take-last/__tests__/async-take-last.auto.spec.ts
+++ b/src/impls/$take-last/__tests__/async-take-last.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTakeLast } from '@iter-tools/es';
+import { asyncTakeLast } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncTakeLast', () => {

--- a/src/impls/$take-last/__tests__/async-take-last.test.js
+++ b/src/impls/$take-last/__tests__/async-take-last.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTakeLast } from '@iter-tools/es';
+import { asyncTakeLast } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncTakeLast', () => {

--- a/src/impls/$take-last/__tests__/take-last.auto.spec.ts
+++ b/src/impls/$take-last/__tests__/take-last.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { takeLast } from '@iter-tools/es';
+import { takeLast } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('takeLast', () => {

--- a/src/impls/$take-last/__tests__/take-last.test.js
+++ b/src/impls/$take-last/__tests__/take-last.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { takeLast } from '@iter-tools/es';
+import { takeLast } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('takeLast', () => {

--- a/src/impls/$take-sorted/__tests__/$take-sorted.test.js
+++ b/src/impls/$take-sorted/__tests__/$take-sorted.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $takeSorted } from '@iter-tools/es';
+import { $takeSorted } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`takeSorted`, () => {

--- a/src/impls/$take-sorted/__tests__/async-take-sorted.auto.spec.ts
+++ b/src/impls/$take-sorted/__tests__/async-take-sorted.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTakeSorted } from '@iter-tools/es';
+import { asyncTakeSorted } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncTakeSorted', () => {

--- a/src/impls/$take-sorted/__tests__/async-take-sorted.test.js
+++ b/src/impls/$take-sorted/__tests__/async-take-sorted.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTakeSorted } from '@iter-tools/es';
+import { asyncTakeSorted } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncTakeSorted', () => {

--- a/src/impls/$take-sorted/__tests__/take-sorted.auto.spec.ts
+++ b/src/impls/$take-sorted/__tests__/take-sorted.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { takeSorted } from '@iter-tools/es';
+import { takeSorted } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('takeSorted', () => {

--- a/src/impls/$take-sorted/__tests__/take-sorted.test.js
+++ b/src/impls/$take-sorted/__tests__/take-sorted.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { takeSorted } from '@iter-tools/es';
+import { takeSorted } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('takeSorted', () => {

--- a/src/impls/$take-while/__tests__/$take-while.test.js
+++ b/src/impls/$take-while/__tests__/$take-while.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $takeWhile } from '@iter-tools/es';
+import { $takeWhile } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`takeWhile`, () => {

--- a/src/impls/$take-while/__tests__/async-take-while.auto.spec.ts
+++ b/src/impls/$take-while/__tests__/async-take-while.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTakeWhile } from '@iter-tools/es';
+import { asyncTakeWhile } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncTakeWhile', () => {

--- a/src/impls/$take-while/__tests__/async-take-while.test.js
+++ b/src/impls/$take-while/__tests__/async-take-while.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTakeWhile } from '@iter-tools/es';
+import { asyncTakeWhile } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncTakeWhile', () => {

--- a/src/impls/$take-while/__tests__/take-while.auto.spec.ts
+++ b/src/impls/$take-while/__tests__/take-while.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { takeWhile } from '@iter-tools/es';
+import { takeWhile } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('takeWhile', () => {

--- a/src/impls/$take-while/__tests__/take-while.test.js
+++ b/src/impls/$take-while/__tests__/take-while.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { takeWhile } from '@iter-tools/es';
+import { takeWhile } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('takeWhile', () => {

--- a/src/impls/$take/__tests__/$take.test.js
+++ b/src/impls/$take/__tests__/$take.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $take } from '@iter-tools/es';
+import { $take } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`take`, () => {

--- a/src/impls/$take/__tests__/async-take.auto.spec.ts
+++ b/src/impls/$take/__tests__/async-take.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTake } from '@iter-tools/es';
+import { asyncTake } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncTake', () => {

--- a/src/impls/$take/__tests__/async-take.test.js
+++ b/src/impls/$take/__tests__/async-take.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTake } from '@iter-tools/es';
+import { asyncTake } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncTake', () => {

--- a/src/impls/$take/__tests__/take.auto.spec.ts
+++ b/src/impls/$take/__tests__/take.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { take } from '@iter-tools/es';
+import { take } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('take', () => {

--- a/src/impls/$take/__tests__/take.test.js
+++ b/src/impls/$take/__tests__/take.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { take } from '@iter-tools/es';
+import { take } from 'iter-tools-es';
 import { wrap, unwrap } from '../../../test/helpers.js';
 
 describe('take', () => {

--- a/src/impls/$tap/__tests__/$tap.test.js
+++ b/src/impls/$tap/__tests__/$tap.test.js
@@ -1,6 +1,6 @@
 import { $, $isAsync, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $tap } from '@iter-tools/es';
+import { $tap } from 'iter-tools-es';
 import { $wrap, $unwrap, anyType } from '../../../test/$helpers.js';
 
 describe($`tap`, () => {

--- a/src/impls/$tap/__tests__/async-tap.auto.spec.ts
+++ b/src/impls/$tap/__tests__/async-tap.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTap } from '@iter-tools/es';
+import { asyncTap } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, anyType } from '../../../test/async-helpers.js';
 
 describe('asyncTap', () => {

--- a/src/impls/$tap/__tests__/async-tap.test.js
+++ b/src/impls/$tap/__tests__/async-tap.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTap } from '@iter-tools/es';
+import { asyncTap } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, anyType } from '../../../test/async-helpers.js';
 
 describe('asyncTap', () => {

--- a/src/impls/$tap/__tests__/tap.auto.spec.ts
+++ b/src/impls/$tap/__tests__/tap.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { tap } from '@iter-tools/es';
+import { tap } from 'iter-tools-es';
 import { wrap, unwrap, anyType } from '../../../test/helpers.js';
 
 describe('tap', () => {

--- a/src/impls/$tap/__tests__/tap.test.js
+++ b/src/impls/$tap/__tests__/tap.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { tap } from '@iter-tools/es';
+import { tap } from 'iter-tools-es';
 import { wrap, unwrap, anyType } from '../../../test/helpers.js';
 
 describe('tap', () => {

--- a/src/impls/$to-array/__tests__/$to-array.test.js
+++ b/src/impls/$to-array/__tests__/$to-array.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $toArray } from '@iter-tools/es';
+import { $toArray } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`toArray`, () => {

--- a/src/impls/$to-array/__tests__/async-to-array.auto.spec.ts
+++ b/src/impls/$to-array/__tests__/async-to-array.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncToArray } from '@iter-tools/es';
+import { asyncToArray } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncToArray', () => {

--- a/src/impls/$to-array/__tests__/async-to-array.test.js
+++ b/src/impls/$to-array/__tests__/async-to-array.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncToArray } from '@iter-tools/es';
+import { asyncToArray } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncToArray', () => {

--- a/src/impls/$to-array/__tests__/to-array.auto.spec.ts
+++ b/src/impls/$to-array/__tests__/to-array.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { toArray } from '@iter-tools/es';
+import { toArray } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('toArray', () => {

--- a/src/impls/$to-array/__tests__/to-array.test.js
+++ b/src/impls/$to-array/__tests__/to-array.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { toArray } from '@iter-tools/es';
+import { toArray } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('toArray', () => {

--- a/src/impls/$to-object/__tests__/$to-object.test.js
+++ b/src/impls/$to-object/__tests__/$to-object.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $toObject } from '@iter-tools/es';
+import { $toObject } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`toObject`, () => {

--- a/src/impls/$to-object/__tests__/async-to-object.auto.spec.ts
+++ b/src/impls/$to-object/__tests__/async-to-object.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncToObject } from '@iter-tools/es';
+import { asyncToObject } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncToObject', () => {

--- a/src/impls/$to-object/__tests__/async-to-object.test.js
+++ b/src/impls/$to-object/__tests__/async-to-object.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncToObject } from '@iter-tools/es';
+import { asyncToObject } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncToObject', () => {

--- a/src/impls/$to-object/__tests__/to-object.auto.spec.ts
+++ b/src/impls/$to-object/__tests__/to-object.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { toObject } from '@iter-tools/es';
+import { toObject } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('toObject', () => {

--- a/src/impls/$to-object/__tests__/to-object.test.js
+++ b/src/impls/$to-object/__tests__/to-object.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { toObject } from '@iter-tools/es';
+import { toObject } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('toObject', () => {

--- a/src/impls/$trailing-window/__tests__/$trailing-window.test.js
+++ b/src/impls/$trailing-window/__tests__/$trailing-window.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $trailingWindow } from '@iter-tools/es';
+import { $trailingWindow } from 'iter-tools-es';
 import { $wrap, $unwrapDeep } from '../../../test/$helpers.js';
 
 describe($`trailingWindow`, () => {

--- a/src/impls/$trailing-window/__tests__/async-trailing-window.auto.spec.ts
+++ b/src/impls/$trailing-window/__tests__/async-trailing-window.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTrailingWindow } from '@iter-tools/es';
+import { asyncTrailingWindow } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncTrailingWindow', () => {

--- a/src/impls/$trailing-window/__tests__/async-trailing-window.test.js
+++ b/src/impls/$trailing-window/__tests__/async-trailing-window.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncTrailingWindow } from '@iter-tools/es';
+import { asyncTrailingWindow } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep } from '../../../test/async-helpers.js';
 
 describe('asyncTrailingWindow', () => {

--- a/src/impls/$trailing-window/__tests__/trailing-window.auto.spec.ts
+++ b/src/impls/$trailing-window/__tests__/trailing-window.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { trailingWindow } from '@iter-tools/es';
+import { trailingWindow } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('trailingWindow', () => {

--- a/src/impls/$trailing-window/__tests__/trailing-window.test.js
+++ b/src/impls/$trailing-window/__tests__/trailing-window.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { trailingWindow } from '@iter-tools/es';
+import { trailingWindow } from 'iter-tools-es';
 import { wrap, unwrapDeep } from '../../../test/helpers.js';
 
 describe('trailingWindow', () => {

--- a/src/impls/$window/__tests__/$window.test.js
+++ b/src/impls/$window/__tests__/$window.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $window } from '@iter-tools/es';
+import { $window } from 'iter-tools-es';
 import { $wrap, $unwrapDeep, anyType } from '../../../test/$helpers.js';
 
 describe($`window`, () => {

--- a/src/impls/$window/__tests__/async-window.auto.spec.ts
+++ b/src/impls/$window/__tests__/async-window.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncWindow } from '@iter-tools/es';
+import { asyncWindow } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep, anyType } from '../../../test/async-helpers.js';
 
 describe('asyncWindow', () => {

--- a/src/impls/$window/__tests__/async-window.test.js
+++ b/src/impls/$window/__tests__/async-window.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncWindow } from '@iter-tools/es';
+import { asyncWindow } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrapDeep, anyType } from '../../../test/async-helpers.js';
 
 describe('asyncWindow', () => {

--- a/src/impls/$window/__tests__/window.auto.spec.ts
+++ b/src/impls/$window/__tests__/window.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { window } from '@iter-tools/es';
+import { window } from 'iter-tools-es';
 import { wrap, unwrapDeep, anyType } from '../../../test/helpers.js';
 
 describe('window', () => {

--- a/src/impls/$window/__tests__/window.test.js
+++ b/src/impls/$window/__tests__/window.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { window } from '@iter-tools/es';
+import { window } from 'iter-tools-es';
 import { wrap, unwrapDeep, anyType } from '../../../test/helpers.js';
 
 describe('window', () => {

--- a/src/impls/$wrap/__tests__/$wrap.test.js
+++ b/src/impls/$wrap/__tests__/$wrap.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $wrap } from '@iter-tools/es';
+import { $wrap } from 'iter-tools-es';
 import { $wrap as $testWrap, $unwrap } from '../../../test/$helpers.js';
 
 describe($`wrap`, () => {

--- a/src/impls/$wrap/__tests__/async-wrap.auto.spec.ts
+++ b/src/impls/$wrap/__tests__/async-wrap.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncWrap } from '@iter-tools/es';
+import { asyncWrap } from 'iter-tools-es';
 import { asyncWrap as asyncTestWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncWrap', () => {

--- a/src/impls/$wrap/__tests__/async-wrap.test.js
+++ b/src/impls/$wrap/__tests__/async-wrap.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncWrap } from '@iter-tools/es';
+import { asyncWrap } from 'iter-tools-es';
 import { asyncWrap as asyncTestWrap, asyncUnwrap } from '../../../test/async-helpers.js';
 
 describe('asyncWrap', () => {

--- a/src/impls/$wrap/__tests__/wrap.auto.spec.ts
+++ b/src/impls/$wrap/__tests__/wrap.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { wrap } from '@iter-tools/es';
+import { wrap } from 'iter-tools-es';
 import { wrap as testWrap, unwrap } from '../../../test/helpers.js';
 
 describe('wrap', () => {

--- a/src/impls/$wrap/__tests__/wrap.test.js
+++ b/src/impls/$wrap/__tests__/wrap.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { wrap } from '@iter-tools/es';
+import { wrap } from 'iter-tools-es';
 import { wrap as testWrap, unwrap } from '../../../test/helpers.js';
 
 describe('wrap', () => {

--- a/src/impls/$zip-all/__tests__/$zip-all.test.js
+++ b/src/impls/$zip-all/__tests__/$zip-all.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $zipAll, $toArray } from '@iter-tools/es';
+import { $zipAll, $toArray } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`zipAll`, () => {

--- a/src/impls/$zip-all/__tests__/async-zip-all.auto.spec.ts
+++ b/src/impls/$zip-all/__tests__/async-zip-all.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncZipAll, asyncToArray } from '@iter-tools/es';
+import { asyncZipAll, asyncToArray } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncZipAll', () => {

--- a/src/impls/$zip-all/__tests__/async-zip-all.test.js
+++ b/src/impls/$zip-all/__tests__/async-zip-all.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncZipAll, asyncToArray } from '@iter-tools/es';
+import { asyncZipAll, asyncToArray } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncZipAll', () => {

--- a/src/impls/$zip-all/__tests__/zip-all.auto.spec.ts
+++ b/src/impls/$zip-all/__tests__/zip-all.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { zipAll, toArray } from '@iter-tools/es';
+import { zipAll, toArray } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('zipAll', () => {

--- a/src/impls/$zip-all/__tests__/zip-all.test.js
+++ b/src/impls/$zip-all/__tests__/zip-all.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { zipAll, toArray } from '@iter-tools/es';
+import { zipAll, toArray } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('zipAll', () => {

--- a/src/impls/$zip/__tests__/$zip.test.js
+++ b/src/impls/$zip/__tests__/$zip.test.js
@@ -1,6 +1,6 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $zip, $toArray } from '@iter-tools/es';
+import { $zip, $toArray } from 'iter-tools-es';
 import { $wrap } from '../../../test/$helpers.js';
 
 describe($`zip`, () => {

--- a/src/impls/$zip/__tests__/async-zip.auto.spec.ts
+++ b/src/impls/$zip/__tests__/async-zip.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncZip, asyncToArray } from '@iter-tools/es';
+import { asyncZip, asyncToArray } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncZip', () => {

--- a/src/impls/$zip/__tests__/async-zip.test.js
+++ b/src/impls/$zip/__tests__/async-zip.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncZip, asyncToArray } from '@iter-tools/es';
+import { asyncZip, asyncToArray } from 'iter-tools-es';
 import { asyncWrap } from '../../../test/async-helpers.js';
 
 describe('asyncZip', () => {

--- a/src/impls/$zip/__tests__/zip.auto.spec.ts
+++ b/src/impls/$zip/__tests__/zip.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { zip, toArray } from '@iter-tools/es';
+import { zip, toArray } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('zip', () => {

--- a/src/impls/$zip/__tests__/zip.test.js
+++ b/src/impls/$zip/__tests__/zip.test.js
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { zip, toArray } from '@iter-tools/es';
+import { zip, toArray } from 'iter-tools-es';
 import { wrap } from '../../../test/helpers.js';
 
 describe('zip', () => {

--- a/src/impls/apply/__tests__/apply.auto.spec.ts
+++ b/src/impls/apply/__tests__/apply.auto.spec.ts
@@ -7,7 +7,7 @@
  */
 
 /* eslint-disable jest/expect-expect */
-import { apply } from '@iter-tools/es';
+import { apply } from 'iter-tools-es';
 
 describe('apply', () => {
   it('passes the function the iterable of arguments provided to it', () => {

--- a/src/impls/apply/__tests__/apply.spec.ts
+++ b/src/impls/apply/__tests__/apply.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'static-type-assert';
-import { apply } from '@iter-tools/es';
+import { apply } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/apply/__tests__/apply.test.js
+++ b/src/impls/apply/__tests__/apply.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest/expect-expect */
-import { apply } from '@iter-tools/es';
+import { apply } from 'iter-tools-es';
 
 describe('apply', () => {
   it('passes the function the iterable of arguments provided to it', () => {

--- a/src/impls/array-first-or/__tests__/array-first-or.auto.spec.ts
+++ b/src/impls/array-first-or/__tests__/array-first-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { arrayFirstOr } from '@iter-tools/es';
+import { arrayFirstOr } from 'iter-tools-es';
 
 describe('arrayFirstOr', () => {
   describe('when there is no array', () => {

--- a/src/impls/array-first-or/__tests__/array-first-or.spec.ts
+++ b/src/impls/array-first-or/__tests__/array-first-or.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'static-type-assert';
-import { arrayFirstOr } from '@iter-tools/es';
+import { arrayFirstOr } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/array-first-or/__tests__/array-first-or.test.js
+++ b/src/impls/array-first-or/__tests__/array-first-or.test.js
@@ -1,4 +1,4 @@
-import { arrayFirstOr } from '@iter-tools/es';
+import { arrayFirstOr } from 'iter-tools-es';
 
 describe('arrayFirstOr', () => {
   describe('when there is no array', () => {

--- a/src/impls/array-first/__tests__/array-first.auto.spec.ts
+++ b/src/impls/array-first/__tests__/array-first.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { arrayFirst } from '@iter-tools/es';
+import { arrayFirst } from 'iter-tools-es';
 
 describe('arrayFirst', () => {
   describe('when there is no array', () => {

--- a/src/impls/array-first/__tests__/array-first.spec.ts
+++ b/src/impls/array-first/__tests__/array-first.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'static-type-assert';
-import { arrayFirst } from '@iter-tools/es';
+import { arrayFirst } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/array-first/__tests__/array-first.test.js
+++ b/src/impls/array-first/__tests__/array-first.test.js
@@ -1,4 +1,4 @@
-import { arrayFirst } from '@iter-tools/es';
+import { arrayFirst } from 'iter-tools-es';
 
 describe('arrayFirst', () => {
   describe('when there is no array', () => {

--- a/src/impls/array-last-or/__tests__/array-last-or.auto.spec.ts
+++ b/src/impls/array-last-or/__tests__/array-last-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { arrayLastOr } from '@iter-tools/es';
+import { arrayLastOr } from 'iter-tools-es';
 
 describe('arrayLastOr', () => {
   describe('when there is no array', () => {

--- a/src/impls/array-last-or/__tests__/array-last-or.test.js
+++ b/src/impls/array-last-or/__tests__/array-last-or.test.js
@@ -1,4 +1,4 @@
-import { arrayLastOr } from '@iter-tools/es';
+import { arrayLastOr } from 'iter-tools-es';
 
 describe('arrayLastOr', () => {
   describe('when there is no array', () => {

--- a/src/impls/array-last/__tests__/array-last.auto.spec.ts
+++ b/src/impls/array-last/__tests__/array-last.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { arrayLast } from '@iter-tools/es';
+import { arrayLast } from 'iter-tools-es';
 
 describe('arrayLast', () => {
   describe('when there is no array', () => {

--- a/src/impls/array-last/__tests__/array-last.test.js
+++ b/src/impls/array-last/__tests__/array-last.test.js
@@ -1,4 +1,4 @@
-import { arrayLast } from '@iter-tools/es';
+import { arrayLast } from 'iter-tools-es';
 
 describe('arrayLast', () => {
   describe('when there is no array', () => {

--- a/src/impls/array-reverse/__tests__/array-reverse.auto.spec.ts
+++ b/src/impls/array-reverse/__tests__/array-reverse.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { arrayReverse, toArray } from '@iter-tools/es';
+import { arrayReverse, toArray } from 'iter-tools-es';
 
 describe('arrayReverse', () => {
   describe('when source is empty', () => {

--- a/src/impls/array-reverse/__tests__/array-reverse.test.js
+++ b/src/impls/array-reverse/__tests__/array-reverse.test.js
@@ -1,4 +1,4 @@
-import { arrayReverse, toArray } from '@iter-tools/es';
+import { arrayReverse, toArray } from 'iter-tools-es';
 
 describe('arrayReverse', () => {
   describe('when source is empty', () => {

--- a/src/impls/async-buffer/__tests__/async-buffer.auto.spec.ts
+++ b/src/impls/async-buffer/__tests__/async-buffer.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncBuffer, asyncToArray } from '@iter-tools/es';
+import { asyncBuffer, asyncToArray } from 'iter-tools-es';
 import { AsyncIterable } from '../../../types/async-iterable.js';
 import { delay } from '../../../internal/delay.js';
 

--- a/src/impls/async-buffer/__tests__/async-buffer.test.js
+++ b/src/impls/async-buffer/__tests__/async-buffer.test.js
@@ -1,4 +1,4 @@
-import { asyncBuffer, asyncToArray } from '@iter-tools/es';
+import { asyncBuffer, asyncToArray } from 'iter-tools-es';
 import { AsyncIterable } from '../../../types/async-iterable.js';
 import { delay } from '../../../internal/delay.js';
 

--- a/src/impls/async-interleave-ready/__tests__/async-interleave-ready.auto.spec.ts
+++ b/src/impls/async-interleave-ready/__tests__/async-interleave-ready.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncInterleaveReady, asyncToArray } from '@iter-tools/es';
+import { asyncInterleaveReady, asyncToArray } from 'iter-tools-es';
 
 import { delay } from '../../../internal/delay.js';
 

--- a/src/impls/async-interleave-ready/__tests__/async-interleave-ready.test.js
+++ b/src/impls/async-interleave-ready/__tests__/async-interleave-ready.test.js
@@ -1,4 +1,4 @@
-import { asyncInterleaveReady, asyncToArray } from '@iter-tools/es';
+import { asyncInterleaveReady, asyncToArray } from 'iter-tools-es';
 
 import { delay } from '../../../internal/delay.js';
 

--- a/src/impls/async-throttle/__tests__/async-throttle.auto.spec.ts
+++ b/src/impls/async-throttle/__tests__/async-throttle.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { asyncThrottle } from '@iter-tools/es';
+import { asyncThrottle } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, anyType } from '../../../test/async-helpers.js';
 
 describe('asyncThrottle', () => {

--- a/src/impls/async-throttle/__tests__/async-throttle.test.js
+++ b/src/impls/async-throttle/__tests__/async-throttle.test.js
@@ -1,4 +1,4 @@
-import { asyncThrottle } from '@iter-tools/es';
+import { asyncThrottle } from 'iter-tools-es';
 import { asyncWrap, asyncUnwrap, anyType } from '../../../test/async-helpers.js';
 
 describe('asyncThrottle', () => {

--- a/src/impls/call/__tests__/call.auto.spec.ts
+++ b/src/impls/call/__tests__/call.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { call } from '@iter-tools/es';
+import { call } from 'iter-tools-es';
 
 describe('call', () => {
   it('calls the passed function', () => {

--- a/src/impls/call/__tests__/call.spec.ts
+++ b/src/impls/call/__tests__/call.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'static-type-assert';
-import { call } from '@iter-tools/es';
+import { call } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/call/__tests__/call.test.js
+++ b/src/impls/call/__tests__/call.test.js
@@ -1,4 +1,4 @@
-import { call } from '@iter-tools/es';
+import { call } from 'iter-tools-es';
 
 describe('call', () => {
   it('calls the passed function', () => {

--- a/src/impls/combinations-with-replacement/__tests__/combinations-with-replacement.auto.spec.ts
+++ b/src/impls/combinations-with-replacement/__tests__/combinations-with-replacement.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { combinationsWithReplacement } from '@iter-tools/es';
+import { combinationsWithReplacement } from 'iter-tools-es';
 
 describe('combinationsWithReplacement', () => {
   it('returns empty', () => {

--- a/src/impls/combinations-with-replacement/__tests__/combinations-with-replacement.test.js
+++ b/src/impls/combinations-with-replacement/__tests__/combinations-with-replacement.test.js
@@ -1,4 +1,4 @@
-import { combinationsWithReplacement } from '@iter-tools/es';
+import { combinationsWithReplacement } from 'iter-tools-es';
 
 describe('combinationsWithReplacement', () => {
   it('returns empty', () => {

--- a/src/impls/combinations/__tests__/combinations.auto.spec.ts
+++ b/src/impls/combinations/__tests__/combinations.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { combinations } from '@iter-tools/es';
+import { combinations } from 'iter-tools-es';
 
 describe('combinations', () => {
   it('returns empty', () => {

--- a/src/impls/combinations/__tests__/combinations.spec.ts
+++ b/src/impls/combinations/__tests__/combinations.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'static-type-assert';
-import { combinations } from '@iter-tools/es';
+import { combinations } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/combinations/__tests__/combinations.test.js
+++ b/src/impls/combinations/__tests__/combinations.test.js
@@ -1,4 +1,4 @@
-import { combinations } from '@iter-tools/es';
+import { combinations } from 'iter-tools-es';
 
 describe('combinations', () => {
   it('returns empty', () => {

--- a/src/impls/compose/__tests__/compose.auto.spec.ts
+++ b/src/impls/compose/__tests__/compose.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { compose } from '@iter-tools/es';
+import { compose } from 'iter-tools-es';
 
 describe('compose', () => {
   it('works', () => {

--- a/src/impls/compose/__tests__/compose.test.js
+++ b/src/impls/compose/__tests__/compose.test.js
@@ -1,4 +1,4 @@
-import { compose } from '@iter-tools/es';
+import { compose } from 'iter-tools-es';
 
 describe('compose', () => {
   it('works', () => {

--- a/src/impls/exec-pipe/__tests__/exec-pipe.auto.spec.ts
+++ b/src/impls/exec-pipe/__tests__/exec-pipe.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { execPipe } from '@iter-tools/es';
+import { execPipe } from 'iter-tools-es';
 
 describe('pipe', () => {
   it('works', () => {

--- a/src/impls/exec-pipe/__tests__/exec-pipe.test.js
+++ b/src/impls/exec-pipe/__tests__/exec-pipe.test.js
@@ -1,4 +1,4 @@
-import { execPipe } from '@iter-tools/es';
+import { execPipe } from 'iter-tools-es';
 
 describe('pipe', () => {
   it('works', () => {

--- a/src/impls/get-size/__tests__/get-size.auto.spec.ts
+++ b/src/impls/get-size/__tests__/get-size.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { getSize } from '@iter-tools/es';
+import { getSize } from 'iter-tools-es';
 
 describe('getSize', () => {
   it('can get the size of a nullish value', () => {

--- a/src/impls/get-size/__tests__/get-size.test.js
+++ b/src/impls/get-size/__tests__/get-size.test.js
@@ -1,4 +1,4 @@
-import { getSize } from '@iter-tools/es';
+import { getSize } from 'iter-tools-es';
 
 describe('getSize', () => {
   it('can get the size of a nullish value', () => {

--- a/src/impls/is-async-iterable/__tests__/is-async-iterable.auto.spec.ts
+++ b/src/impls/is-async-iterable/__tests__/is-async-iterable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isAsyncIterable } from '@iter-tools/es';
+import { isAsyncIterable } from 'iter-tools-es';
 
 describe('isAsyncIterable', () => {
   describe('when value is an async iterable', () => {

--- a/src/impls/is-async-iterable/__tests__/is-async-iterable.spec.ts
+++ b/src/impls/is-async-iterable/__tests__/is-async-iterable.spec.ts
@@ -1,4 +1,4 @@
-import { isAsyncIterable } from '@iter-tools/es';
+import { isAsyncIterable } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-async-iterable/__tests__/is-async-iterable.test.js
+++ b/src/impls/is-async-iterable/__tests__/is-async-iterable.test.js
@@ -1,4 +1,4 @@
-import { isAsyncIterable } from '@iter-tools/es';
+import { isAsyncIterable } from 'iter-tools-es';
 
 describe('isAsyncIterable', () => {
   describe('when value is an async iterable', () => {

--- a/src/impls/is-async-loopable/__tests__/is-async-loopable.auto.spec.ts
+++ b/src/impls/is-async-loopable/__tests__/is-async-loopable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isAsyncLoopable } from '@iter-tools/es';
+import { isAsyncLoopable } from 'iter-tools-es';
 
 describe('isAsyncLoopable', () => {
   describe('when value can be used with a `for await..of` loop', () => {

--- a/src/impls/is-async-loopable/__tests__/is-async-loopable.spec.ts
+++ b/src/impls/is-async-loopable/__tests__/is-async-loopable.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { isAsyncLoopable } from '@iter-tools/es';
+import { isAsyncLoopable } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-async-loopable/__tests__/is-async-loopable.test.js
+++ b/src/impls/is-async-loopable/__tests__/is-async-loopable.test.js
@@ -1,4 +1,4 @@
-import { isAsyncLoopable } from '@iter-tools/es';
+import { isAsyncLoopable } from 'iter-tools-es';
 
 describe('isAsyncLoopable', () => {
   describe('when value can be used with a `for await..of` loop', () => {

--- a/src/impls/is-async-wrappable/__tests__/is-async-wrappable.auto.spec.ts
+++ b/src/impls/is-async-wrappable/__tests__/is-async-wrappable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isAsyncWrappable } from '@iter-tools/es';
+import { isAsyncWrappable } from 'iter-tools-es';
 
 describe('isAsyncWrappable', () => {
   describe('when value can be used with asyncWrap', () => {

--- a/src/impls/is-async-wrappable/__tests__/is-async-wrappable.spec.ts
+++ b/src/impls/is-async-wrappable/__tests__/is-async-wrappable.spec.ts
@@ -1,4 +1,4 @@
-import { isAsyncWrappable, asyncWrap } from '@iter-tools/es';
+import { isAsyncWrappable, asyncWrap } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-async-wrappable/__tests__/is-async-wrappable.test.js
+++ b/src/impls/is-async-wrappable/__tests__/is-async-wrappable.test.js
@@ -1,4 +1,4 @@
-import { isAsyncWrappable } from '@iter-tools/es';
+import { isAsyncWrappable } from 'iter-tools-es';
 
 describe('isAsyncWrappable', () => {
   describe('when value can be used with asyncWrap', () => {

--- a/src/impls/is-iterable/__tests__/is-iterable.auto.spec.ts
+++ b/src/impls/is-iterable/__tests__/is-iterable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isIterable } from '@iter-tools/es';
+import { isIterable } from 'iter-tools-es';
 
 describe('isIterable', () => {
   describe('when value has Symbol.iterator', () => {

--- a/src/impls/is-iterable/__tests__/is-iterable.spec.ts
+++ b/src/impls/is-iterable/__tests__/is-iterable.spec.ts
@@ -1,4 +1,4 @@
-import { isIterable } from '@iter-tools/es';
+import { isIterable } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-iterable/__tests__/is-iterable.test.js
+++ b/src/impls/is-iterable/__tests__/is-iterable.test.js
@@ -1,4 +1,4 @@
-import { isIterable } from '@iter-tools/es';
+import { isIterable } from 'iter-tools-es';
 
 describe('isIterable', () => {
   describe('when value has Symbol.iterator', () => {

--- a/src/impls/is-loopable/__tests__/is-loopable.auto.spec.ts
+++ b/src/impls/is-loopable/__tests__/is-loopable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isLoopable } from '@iter-tools/es';
+import { isLoopable } from 'iter-tools-es';
 
 describe('isLoopable', () => {
   describe('when value has Symbol.iterator', () => {

--- a/src/impls/is-loopable/__tests__/is-loopable.spec.ts
+++ b/src/impls/is-loopable/__tests__/is-loopable.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { isLoopable } from '@iter-tools/es';
+import { isLoopable } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-loopable/__tests__/is-loopable.test.js
+++ b/src/impls/is-loopable/__tests__/is-loopable.test.js
@@ -1,4 +1,4 @@
-import { isLoopable } from '@iter-tools/es';
+import { isLoopable } from 'iter-tools-es';
 
 describe('isLoopable', () => {
   describe('when value has Symbol.iterator', () => {

--- a/src/impls/is-nil/__tests__/is-nil.auto.spec.ts
+++ b/src/impls/is-nil/__tests__/is-nil.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isNil } from '@iter-tools/es';
+import { isNil } from 'iter-tools-es';
 
 describe('isNil', () => {
   describe('when value is null or undefined', () => {

--- a/src/impls/is-nil/__tests__/is-nil.spec.ts
+++ b/src/impls/is-nil/__tests__/is-nil.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { isNil } from '@iter-tools/es';
+import { isNil } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-nil/__tests__/is-nil.test.js
+++ b/src/impls/is-nil/__tests__/is-nil.test.js
@@ -1,4 +1,4 @@
-import { isNil } from '@iter-tools/es';
+import { isNil } from 'iter-tools-es';
 
 describe('isNil', () => {
   describe('when value is null or undefined', () => {

--- a/src/impls/is-null/__tests__/is-null.auto.spec.ts
+++ b/src/impls/is-null/__tests__/is-null.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isNull } from '@iter-tools/es';
+import { isNull } from 'iter-tools-es';
 
 describe('isNull', () => {
   describe('when value is null', () => {

--- a/src/impls/is-null/__tests__/is-null.spec.ts
+++ b/src/impls/is-null/__tests__/is-null.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { isNull } from '@iter-tools/es';
+import { isNull } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-null/__tests__/is-null.test.js
+++ b/src/impls/is-null/__tests__/is-null.test.js
@@ -1,4 +1,4 @@
-import { isNull } from '@iter-tools/es';
+import { isNull } from 'iter-tools-es';
 
 describe('isNull', () => {
   describe('when value is null', () => {

--- a/src/impls/is-undefined/__tests__/is-undefined.auto.spec.ts
+++ b/src/impls/is-undefined/__tests__/is-undefined.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isUndefined } from '@iter-tools/es';
+import { isUndefined } from 'iter-tools-es';
 
 describe('isUndefined', () => {
   describe('when value is undefined', () => {

--- a/src/impls/is-undefined/__tests__/is-undefined.spec.ts
+++ b/src/impls/is-undefined/__tests__/is-undefined.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { isUndefined } from '@iter-tools/es';
+import { isUndefined } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-undefined/__tests__/is-undefined.test.js
+++ b/src/impls/is-undefined/__tests__/is-undefined.test.js
@@ -1,4 +1,4 @@
-import { isUndefined } from '@iter-tools/es';
+import { isUndefined } from 'iter-tools-es';
 
 describe('isUndefined', () => {
   describe('when value is undefined', () => {

--- a/src/impls/is-wrappable/__tests__/is-wrappable.auto.spec.ts
+++ b/src/impls/is-wrappable/__tests__/is-wrappable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { isWrappable } from '@iter-tools/es';
+import { isWrappable } from 'iter-tools-es';
 
 describe('isWrappable', () => {
   describe('when value can be an input to wrap', () => {

--- a/src/impls/is-wrappable/__tests__/is-wrappable.spec.ts
+++ b/src/impls/is-wrappable/__tests__/is-wrappable.spec.ts
@@ -1,4 +1,4 @@
-import { isWrappable, wrap } from '@iter-tools/es';
+import { isWrappable, wrap } from 'iter-tools-es';
 
 declare const value: unknown;
 

--- a/src/impls/is-wrappable/__tests__/is-wrappable.test.js
+++ b/src/impls/is-wrappable/__tests__/is-wrappable.test.js
@@ -1,4 +1,4 @@
-import { isWrappable } from '@iter-tools/es';
+import { isWrappable } from 'iter-tools-es';
 
 describe('isWrappable', () => {
   describe('when value can be an input to wrap', () => {

--- a/src/impls/not-async-iterable/__tests__/not-async-iterable.auto.spec.ts
+++ b/src/impls/not-async-iterable/__tests__/not-async-iterable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notAsyncIterable } from '@iter-tools/es';
+import { notAsyncIterable } from 'iter-tools-es';
 
 describe('notAsyncIterable', () => {
   describe('when value is an async iterable', () => {

--- a/src/impls/not-async-iterable/__tests__/not-async-iterable.spec.ts
+++ b/src/impls/not-async-iterable/__tests__/not-async-iterable.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notAsyncIterable } from '@iter-tools/es';
+import { notAsyncIterable } from 'iter-tools-es';
 
 declare const value: AsyncIterable<any> | number;
 if (notAsyncIterable(value)) {

--- a/src/impls/not-async-iterable/__tests__/not-async-iterable.test.js
+++ b/src/impls/not-async-iterable/__tests__/not-async-iterable.test.js
@@ -1,4 +1,4 @@
-import { notAsyncIterable } from '@iter-tools/es';
+import { notAsyncIterable } from 'iter-tools-es';
 
 describe('notAsyncIterable', () => {
   describe('when value is an async iterable', () => {

--- a/src/impls/not-async-loopable/__tests__/not-async-loopable.auto.spec.ts
+++ b/src/impls/not-async-loopable/__tests__/not-async-loopable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notAsyncLoopable } from '@iter-tools/es';
+import { notAsyncLoopable } from 'iter-tools-es';
 
 describe('notAsyncLoopable', () => {
   describe('when value can be used with a `for await..of` loop', () => {

--- a/src/impls/not-async-loopable/__tests__/not-async-loopable.spec.ts
+++ b/src/impls/not-async-loopable/__tests__/not-async-loopable.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notAsyncLoopable } from '@iter-tools/es';
+import { notAsyncLoopable } from 'iter-tools-es';
 
 declare const value: AsyncIterable<any> | Iterable<any> | number;
 if (notAsyncLoopable(value)) {

--- a/src/impls/not-async-loopable/__tests__/not-async-loopable.test.js
+++ b/src/impls/not-async-loopable/__tests__/not-async-loopable.test.js
@@ -1,4 +1,4 @@
-import { notAsyncLoopable } from '@iter-tools/es';
+import { notAsyncLoopable } from 'iter-tools-es';
 
 describe('notAsyncLoopable', () => {
   describe('when value can be used with a `for await..of` loop', () => {

--- a/src/impls/not-async-wrappable/__tests__/not-async-wrappable.auto.spec.ts
+++ b/src/impls/not-async-wrappable/__tests__/not-async-wrappable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notAsyncWrappable } from '@iter-tools/es';
+import { notAsyncWrappable } from 'iter-tools-es';
 
 describe('notAsyncWrappable', () => {
   describe('when value can be used with asyncWrap', () => {

--- a/src/impls/not-async-wrappable/__tests__/not-async-wrappable.spec.ts
+++ b/src/impls/not-async-wrappable/__tests__/not-async-wrappable.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notAsyncWrappable } from '@iter-tools/es';
+import { notAsyncWrappable } from 'iter-tools-es';
 
 declare const value: AsyncIterable<any> | Iterable<any> | null | undefined | number;
 if (notAsyncWrappable(value)) {

--- a/src/impls/not-async-wrappable/__tests__/not-async-wrappable.test.js
+++ b/src/impls/not-async-wrappable/__tests__/not-async-wrappable.test.js
@@ -1,4 +1,4 @@
-import { notAsyncWrappable } from '@iter-tools/es';
+import { notAsyncWrappable } from 'iter-tools-es';
 
 describe('notAsyncWrappable', () => {
   describe('when value can be used with asyncWrap', () => {

--- a/src/impls/not-iterable/__tests__/not-iterable.auto.spec.ts
+++ b/src/impls/not-iterable/__tests__/not-iterable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notIterable } from '@iter-tools/es';
+import { notIterable } from 'iter-tools-es';
 
 describe('notIterable', () => {
   describe('when value has Symbol.iterator', () => {

--- a/src/impls/not-iterable/__tests__/not-iterable.spec.ts
+++ b/src/impls/not-iterable/__tests__/not-iterable.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notIterable } from '@iter-tools/es';
+import { notIterable } from 'iter-tools-es';
 
 declare const value: Iterable<any> | number;
 if (notIterable(value)) {

--- a/src/impls/not-iterable/__tests__/not-iterable.test.js
+++ b/src/impls/not-iterable/__tests__/not-iterable.test.js
@@ -1,4 +1,4 @@
-import { notIterable } from '@iter-tools/es';
+import { notIterable } from 'iter-tools-es';
 
 describe('notIterable', () => {
   describe('when value has Symbol.iterator', () => {

--- a/src/impls/not-loopable/__tests__/not-loopable.auto.spec.ts
+++ b/src/impls/not-loopable/__tests__/not-loopable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notLoopable } from '@iter-tools/es';
+import { notLoopable } from 'iter-tools-es';
 
 describe('notLoopable', () => {
   describe('when value has Symbol.iterator', () => {

--- a/src/impls/not-loopable/__tests__/not-loopable.spec.ts
+++ b/src/impls/not-loopable/__tests__/not-loopable.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notLoopable } from '@iter-tools/es';
+import { notLoopable } from 'iter-tools-es';
 
 declare const value: Iterable<any> | number;
 if (notLoopable(value)) {

--- a/src/impls/not-loopable/__tests__/not-loopable.test.js
+++ b/src/impls/not-loopable/__tests__/not-loopable.test.js
@@ -1,4 +1,4 @@
-import { notLoopable } from '@iter-tools/es';
+import { notLoopable } from 'iter-tools-es';
 
 describe('notLoopable', () => {
   describe('when value has Symbol.iterator', () => {

--- a/src/impls/not-nil/__tests__/not-nil.auto.spec.ts
+++ b/src/impls/not-nil/__tests__/not-nil.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notNil } from '@iter-tools/es';
+import { notNil } from 'iter-tools-es';
 
 describe('notNil', () => {
   describe('when value is null or undefined', () => {

--- a/src/impls/not-nil/__tests__/not-nil.spec.ts
+++ b/src/impls/not-nil/__tests__/not-nil.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notNil } from '@iter-tools/es';
+import { notNil } from 'iter-tools-es';
 
 declare const value: null | undefined | number;
 if (notNil(value)) {

--- a/src/impls/not-nil/__tests__/not-nil.test.js
+++ b/src/impls/not-nil/__tests__/not-nil.test.js
@@ -1,4 +1,4 @@
-import { notNil } from '@iter-tools/es';
+import { notNil } from 'iter-tools-es';
 
 describe('notNil', () => {
   describe('when value is null or undefined', () => {

--- a/src/impls/not-null/__tests__/not-null.auto.spec.ts
+++ b/src/impls/not-null/__tests__/not-null.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notNull } from '@iter-tools/es';
+import { notNull } from 'iter-tools-es';
 
 describe('notNull', () => {
   describe('when value is null', () => {

--- a/src/impls/not-null/__tests__/not-null.spec.ts
+++ b/src/impls/not-null/__tests__/not-null.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notNull } from '@iter-tools/es';
+import { notNull } from 'iter-tools-es';
 
 declare const value: null | number;
 if (notNull(value)) {

--- a/src/impls/not-null/__tests__/not-null.test.js
+++ b/src/impls/not-null/__tests__/not-null.test.js
@@ -1,4 +1,4 @@
-import { notNull } from '@iter-tools/es';
+import { notNull } from 'iter-tools-es';
 
 describe('notNull', () => {
   describe('when value is null', () => {

--- a/src/impls/not-undefined/__tests__/not-undefined.auto.spec.ts
+++ b/src/impls/not-undefined/__tests__/not-undefined.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notUndefined } from '@iter-tools/es';
+import { notUndefined } from 'iter-tools-es';
 
 describe('notUndefined', () => {
   describe('when value is undefined', () => {

--- a/src/impls/not-undefined/__tests__/not-undefined.spec.ts
+++ b/src/impls/not-undefined/__tests__/not-undefined.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notUndefined } from '@iter-tools/es';
+import { notUndefined } from 'iter-tools-es';
 
 declare const value: undefined | number;
 if (notUndefined(value)) {

--- a/src/impls/not-undefined/__tests__/not-undefined.test.js
+++ b/src/impls/not-undefined/__tests__/not-undefined.test.js
@@ -1,4 +1,4 @@
-import { notUndefined } from '@iter-tools/es';
+import { notUndefined } from 'iter-tools-es';
 
 describe('notUndefined', () => {
   describe('when value is undefined', () => {

--- a/src/impls/not-wrappable/__tests__/not-wrappable.auto.spec.ts
+++ b/src/impls/not-wrappable/__tests__/not-wrappable.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { notWrappable } from '@iter-tools/es';
+import { notWrappable } from 'iter-tools-es';
 
 describe('notWrappable', () => {
   describe('when value can be an input to wrap', () => {

--- a/src/impls/not-wrappable/__tests__/not-wrappable.spec.ts
+++ b/src/impls/not-wrappable/__tests__/not-wrappable.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 
-import { notWrappable } from '@iter-tools/es';
+import { notWrappable } from 'iter-tools-es';
 
 declare const value: Iterable<any> | undefined | null | number;
 if (notWrappable(value)) {

--- a/src/impls/not-wrappable/__tests__/not-wrappable.test.js
+++ b/src/impls/not-wrappable/__tests__/not-wrappable.test.js
@@ -1,4 +1,4 @@
-import { notWrappable } from '@iter-tools/es';
+import { notWrappable } from 'iter-tools-es';
 
 describe('notWrappable', () => {
   describe('when value can be an input to wrap', () => {

--- a/src/impls/null-or-async/__tests__/null-or-async.auto.spec.ts
+++ b/src/impls/null-or-async/__tests__/null-or-async.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { nullOrAsync, arrayFromAsync } from '@iter-tools/es';
+import { nullOrAsync, arrayFromAsync } from 'iter-tools-es';
 
 describe('nullOrAsync', () => {
   it('empty array returns null', async () => {

--- a/src/impls/null-or-async/__tests__/null-or-async.test.js
+++ b/src/impls/null-or-async/__tests__/null-or-async.test.js
@@ -1,4 +1,4 @@
-import { nullOrAsync, arrayFromAsync } from '@iter-tools/es';
+import { nullOrAsync, arrayFromAsync } from 'iter-tools-es';
 
 describe('nullOrAsync', () => {
   it('empty array returns null', async () => {

--- a/src/impls/null-or/__tests__/null-or.auto.spec.ts
+++ b/src/impls/null-or/__tests__/null-or.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { nullOr, arrayFrom } from '@iter-tools/es';
+import { nullOr, arrayFrom } from 'iter-tools-es';
 
 describe('nullOr', () => {
   it('empty array returns null', () => {

--- a/src/impls/null-or/__tests__/null-or.test.js
+++ b/src/impls/null-or/__tests__/null-or.test.js
@@ -1,4 +1,4 @@
-import { nullOr, arrayFrom } from '@iter-tools/es';
+import { nullOr, arrayFrom } from 'iter-tools-es';
 
 describe('nullOr', () => {
   it('empty array returns null', () => {

--- a/src/impls/object-entries/__tests__/object-entries.auto.spec.ts
+++ b/src/impls/object-entries/__tests__/object-entries.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { objectEntries } from '@iter-tools/es';
+import { objectEntries } from 'iter-tools-es';
 
 describe('objectEntries', () => {
   it('works with Objects', () => {

--- a/src/impls/object-entries/__tests__/object-entries.spec.ts
+++ b/src/impls/object-entries/__tests__/object-entries.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 import { ResultIterable } from '../../../types/iterable';
-import { objectEntries } from '@iter-tools/es';
+import { objectEntries } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/object-entries/__tests__/object-entries.test.js
+++ b/src/impls/object-entries/__tests__/object-entries.test.js
@@ -1,4 +1,4 @@
-import { objectEntries } from '@iter-tools/es';
+import { objectEntries } from 'iter-tools-es';
 
 describe('objectEntries', () => {
   it('works with Objects', () => {

--- a/src/impls/object-keys/__tests__/object-keys.auto.spec.ts
+++ b/src/impls/object-keys/__tests__/object-keys.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { objectKeys } from '@iter-tools/es';
+import { objectKeys } from 'iter-tools-es';
 
 describe('objectKeys', () => {
   it('works with Objects', () => {

--- a/src/impls/object-keys/__tests__/object-keys.spec.ts
+++ b/src/impls/object-keys/__tests__/object-keys.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 import { ResultIterable } from '../../../types/iterable';
-import { objectKeys } from '@iter-tools/es';
+import { objectKeys } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/object-keys/__tests__/object-keys.test.js
+++ b/src/impls/object-keys/__tests__/object-keys.test.js
@@ -1,4 +1,4 @@
-import { objectKeys } from '@iter-tools/es';
+import { objectKeys } from 'iter-tools-es';
 
 describe('objectKeys', () => {
   it('works with Objects', () => {

--- a/src/impls/object-values/__tests__/object-values.auto.spec.ts
+++ b/src/impls/object-values/__tests__/object-values.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { objectValues } from '@iter-tools/es';
+import { objectValues } from 'iter-tools-es';
 
 describe('objectValues', () => {
   it('works with Objects', () => {

--- a/src/impls/object-values/__tests__/object-values.spec.ts
+++ b/src/impls/object-values/__tests__/object-values.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 import { ResultIterable } from '../../../types/iterable';
-import { objectValues } from '@iter-tools/es';
+import { objectValues } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/object-values/__tests__/object-values.test.js
+++ b/src/impls/object-values/__tests__/object-values.test.js
@@ -1,4 +1,4 @@
-import { objectValues } from '@iter-tools/es';
+import { objectValues } from 'iter-tools-es';
 
 describe('objectValues', () => {
   it('works with Objects', () => {

--- a/src/impls/permutations/__tests__/permutations.auto.spec.ts
+++ b/src/impls/permutations/__tests__/permutations.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { permutations } from '@iter-tools/es';
+import { permutations } from 'iter-tools-es';
 
 describe('permutations', () => {
   it('returns empty when there are no values to permute', () => {

--- a/src/impls/permutations/__tests__/permutations.spec.ts
+++ b/src/impls/permutations/__tests__/permutations.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'static-type-assert';
-import { permutations } from '@iter-tools/es';
+import { permutations } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/permutations/__tests__/permutations.test.js
+++ b/src/impls/permutations/__tests__/permutations.test.js
@@ -1,4 +1,4 @@
-import { permutations } from '@iter-tools/es';
+import { permutations } from 'iter-tools-es';
 
 describe('permutations', () => {
   it('returns empty when there are no values to permute', () => {

--- a/src/impls/pipe/__tests__/pipe.auto.spec.ts
+++ b/src/impls/pipe/__tests__/pipe.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { pipe } from '@iter-tools/es';
+import { pipe } from 'iter-tools-es';
 
 describe('pipe', () => {
   it('works', () => {

--- a/src/impls/pipe/__tests__/pipe.test.js
+++ b/src/impls/pipe/__tests__/pipe.test.js
@@ -1,4 +1,4 @@
-import { pipe } from '@iter-tools/es';
+import { pipe } from 'iter-tools-es';
 
 describe('pipe', () => {
   it('works', () => {

--- a/src/impls/product/__tests__/product.auto.spec.ts
+++ b/src/impls/product/__tests__/product.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { product } from '@iter-tools/es';
+import { product } from 'iter-tools-es';
 
 describe('product', () => {
   it('returns empty', () => {

--- a/src/impls/product/__tests__/product.spec.ts
+++ b/src/impls/product/__tests__/product.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'static-type-assert';
-import { product } from '@iter-tools/es';
+import { product } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/product/__tests__/product.test.js
+++ b/src/impls/product/__tests__/product.test.js
@@ -1,4 +1,4 @@
-import { product } from '@iter-tools/es';
+import { product } from 'iter-tools-es';
 
 describe('product', () => {
   it('returns empty', () => {

--- a/src/impls/range/__tests__/range.auto.spec.ts
+++ b/src/impls/range/__tests__/range.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { range } from '@iter-tools/es';
+import { range } from 'iter-tools-es';
 import { anyType, unwrap } from '../../../test/helpers.js';
 
 describe('range', () => {

--- a/src/impls/range/__tests__/range.spec.ts
+++ b/src/impls/range/__tests__/range.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'static-type-assert';
 import { ResultIterable } from '../../../types/iterable';
-import { range } from '@iter-tools/es';
+import { range } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/range/__tests__/range.test.js
+++ b/src/impls/range/__tests__/range.test.js
@@ -1,4 +1,4 @@
-import { range } from '@iter-tools/es';
+import { range } from 'iter-tools-es';
 import { anyType, unwrap } from '../../../test/helpers.js';
 
 describe('range', () => {

--- a/src/impls/repeat-times/__tests__/repeat-times.auto.spec.ts
+++ b/src/impls/repeat-times/__tests__/repeat-times.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { repeatTimes } from '@iter-tools/es';
+import { repeatTimes } from 'iter-tools-es';
 
 describe('repeatTimes', () => {
   it('repeats a value n times', () => {

--- a/src/impls/repeat-times/__tests__/repeat-times.test.js
+++ b/src/impls/repeat-times/__tests__/repeat-times.test.js
@@ -1,4 +1,4 @@
-import { repeatTimes } from '@iter-tools/es';
+import { repeatTimes } from 'iter-tools-es';
 
 describe('repeatTimes', () => {
   it('repeats a value n times', () => {

--- a/src/impls/repeat/__tests__/repeat.auto.spec.ts
+++ b/src/impls/repeat/__tests__/repeat.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { repeat, slice } from '@iter-tools/es';
+import { repeat, slice } from 'iter-tools-es';
 
 describe('repeat', () => {
   it('repeats infinitely', () => {

--- a/src/impls/repeat/__tests__/repeat.test.js
+++ b/src/impls/repeat/__tests__/repeat.test.js
@@ -1,4 +1,4 @@
-import { repeat, slice } from '@iter-tools/es';
+import { repeat, slice } from 'iter-tools-es';
 
 describe('repeat', () => {
   it('repeats infinitely', () => {

--- a/src/impls/when/__tests__/when.auto.spec.ts
+++ b/src/impls/when/__tests__/when.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { when } from '@iter-tools/es';
+import { when } from 'iter-tools-es';
 
 const obj = { foo: 'foo' };
 const iterable = ['foo'];

--- a/src/impls/when/__tests__/when.spec.ts
+++ b/src/impls/when/__tests__/when.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'static-type-assert';
-import { when } from '@iter-tools/es';
+import { when } from 'iter-tools-es';
 
 declare const Ø: never;
 

--- a/src/impls/when/__tests__/when.test.js
+++ b/src/impls/when/__tests__/when.test.js
@@ -1,4 +1,4 @@
-import { when } from '@iter-tools/es';
+import { when } from 'iter-tools-es';
 
 const obj = { foo: 'foo' };
 const iterable = ['foo'];

--- a/src/impls/wrap-entries/__tests__/wrap-entries.auto.spec.ts
+++ b/src/impls/wrap-entries/__tests__/wrap-entries.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { wrapEntries } from '@iter-tools/es';
+import { wrapEntries } from 'iter-tools-es';
 
 describe('wrapEntries', () => {
   it('works with Map', () => {

--- a/src/impls/wrap-entries/__tests__/wrap-entries.test.js
+++ b/src/impls/wrap-entries/__tests__/wrap-entries.test.js
@@ -1,4 +1,4 @@
-import { wrapEntries } from '@iter-tools/es';
+import { wrapEntries } from 'iter-tools-es';
 
 describe('wrapEntries', () => {
   it('works with Map', () => {

--- a/src/impls/wrap-keys/__tests__/wrap-keys.auto.spec.ts
+++ b/src/impls/wrap-keys/__tests__/wrap-keys.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { wrapKeys } from '@iter-tools/es';
+import { wrapKeys } from 'iter-tools-es';
 
 describe('wrapKeys', () => {
   it('works with Map', () => {

--- a/src/impls/wrap-keys/__tests__/wrap-keys.test.js
+++ b/src/impls/wrap-keys/__tests__/wrap-keys.test.js
@@ -1,4 +1,4 @@
-import { wrapKeys } from '@iter-tools/es';
+import { wrapKeys } from 'iter-tools-es';
 
 describe('wrapKeys', () => {
   it('works with Map', () => {

--- a/src/impls/wrap-values/__tests__/wrap-values.auto.spec.ts
+++ b/src/impls/wrap-values/__tests__/wrap-values.auto.spec.ts
@@ -6,7 +6,7 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { wrapValues } from '@iter-tools/es';
+import { wrapValues } from 'iter-tools-es';
 
 describe('wrapValues', () => {
   it('works with Map', () => {

--- a/src/impls/wrap-values/__tests__/wrap-values.test.js
+++ b/src/impls/wrap-values/__tests__/wrap-values.test.js
@@ -1,4 +1,4 @@
-import { wrapValues } from '@iter-tools/es';
+import { wrapValues } from 'iter-tools-es';
 
 describe('wrapValues', () => {
   it('works with Map', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "types": ["jest"],
     "baseUrl": ".",
     "paths": {
-      "@iter-tools/es": ["."]
+      "iter-tools-es": ["."]
     }
   },
   "include": ["src/**/__tests__/*.ts", "src/test/setup.d.ts"],


### PR DESCRIPTION
The name of the new package needs to be `iter-tools-es` because there will be other packages in the iter-tools npm organization that may wish to publish es and es5 variants. As it is not legal to have e.g. `@iter-tools/regex/es` as a package name, we need to establish the `-es` convention instead.