### PR TITLE
Peekerator improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - `joinAsString`, `asyncJoinAsString` (Instead use `str(join(...))`)
  - `joinAsStringWith`, `asyncJoinAsStringWith` (Instead use `str(joinWith(sep, ...))`)
  - `regexpExec`
- - `nullOr`, `nullOrAsync`
+ - `nullOr`, `nullOrAsync` (Instead use `peekerate`)
 
 **Arguments**
  - `n` from `fork` and `asyncFork`. Use destructuring or call `return()` on the forks iterable.
@@ -72,13 +72,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - `useFiller` option for `leadingWindow` and `asyncLeadingWindow`.
  - `proto` passed to `Object.create` for `objectFrom` and `objectFromAsync` (also `toObject` and `asyncToObject`).
 
-**Classes**
- - `Peekerator`, `PeekeratorClass`, `AsyncPeekerator`, `AsyncPeekeratorClass`
+**Instance Methods**
+ - Peekerator: `asIterator` method
 
 ### Changed
  - Removed O(1) array optimizations from `last` and `lastOr`
  - Factorial no attempts to use BigNum internally. Some inputs may now cause `combinations().size` or `combinationsWithReplacement().size` to overflow during computation.
 
+**Instance Methods**
+ - Peekerator: `advance` and `return` methods now return `this` (was `undefined`).
 
 
 ## [7.0.0-rc.0] - 2019-12-13

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -1,3 +1,38 @@
 # The iter-tools Cookbook
 
-The iter-tools cookbook is currently undergoing renovations.
+### Printing a list
+
+```js
+function printListEN(values, oxfordComma = true) {
+  const peekr = $peekerate(values);
+  let result = '';
+
+  if (peekr.done) return 'none';
+  let last;
+  while (!peekr.done) {
+    last = peekr.current;
+    peekr.advance();
+    if (!peekr.done) {
+      if (peekr.index > 1) result += ', ';
+      result += last.value.toString();
+    }
+  }
+
+  if (peekr.index > 2) {
+    if (oxfordComma) {
+      result += ', ';
+    }
+    result += 'and ';
+  } else if (peekr.index > 1) {
+    result += ' and ';
+  }
+
+  result += last.value.toString();
+  return result;
+});
+
+printListEN([])); // 'none'
+printListEN([1])); // '1'
+printListEN([1, 2])); // '1 and 2'
+printListEN([1, 2, 3])); // '1, 2, and 3'
+```

--- a/src/impls/$peekerate/$peekerate.d.ts
+++ b/src/impls/$peekerate/$peekerate.d.ts
@@ -1,26 +1,36 @@
-import { $Promise } from '../../../generate/async.macro.cjs';
+import { $iteratorSymbol, $Promise } from '../../../generate/async.macro.cjs';
 
-import { $SourceIterable } from '../../types/$iterable';
+import { $SourceIterable, $IteratorResult } from '../../types/$iterable';
 
-interface $PeekeratorBase {
-  advance(): $Promise<void>;
-  return(): $Promise<void>;
-  readonly index: number;
+export interface $PeekeratorIterator<T> {
+  next(): $IteratorResult<T>;
+  return(): $IteratorResult<T>;
+  [$iteratorSymbol](): this;
 }
 
-interface $DonePeekerator extends $PeekeratorBase {
+interface $PeekeratorBase<T> {
+  readonly index: number;
+
+  /* eslint-disable no-use-before-define */
+  advance(): $Promise<$Peekerator<T>>;
+  return(): $Promise<$Peekerator<T>>;
+  /* eslint-enaable no-use-before-define */
+  asIterator(): $PeekeratorIterator<T>;
+}
+
+interface $DonePeekerator<T> extends $PeekeratorBase<T> {
   readonly current: { done: true; value: undefined };
   readonly done: true;
   readonly value: undefined;
 }
 
-interface $ValuePeekerator<T> extends $PeekeratorBase {
+interface $ValuePeekerator<T> extends $PeekeratorBase<T> {
   readonly current: { done: false; value: T };
   readonly done: false;
   readonly value: T;
 }
 
-export type $Peekerator<T> = $DonePeekerator | $ValuePeekerator<T>;
+export type $Peekerator<T> = $DonePeekerator<T> | $ValuePeekerator<T>;
 
 declare function $peekerate<T>(source: $SourceIterable<T>): $Peekerator<T>;
 

--- a/src/impls/$peekerate/README.async.md
+++ b/src/impls/$peekerate/README.async.md
@@ -3,10 +3,16 @@ See [peekerate](#peekerate)
 Note: Returns a promise of a peekerator, which is necessary for the first value to be fetched.
 
 ```js
-const peekerator = await asyncPeekerate([1, 2, 3]);
+function asyncPrintValues(values) {
+  const peekr = await asyncPeekerate(values);
 
-while (!peekerator.done) {
-  log(peekerator.value + 1);
-  await peekerator.advance();
+  return peekr.done
+    ? 'none'
+    : stringFromAsync(
+        asyncInterposeSeq(', ', peekr.asIterator()),
+      );
 }
+
+asyncPrintValues(asyncWrap([])); // 'none'
+asyncPrintValues(asyncWrap([1, 2, 3])); // '1, 2, 3'
 ```

--- a/src/impls/$peekerate/README.md
+++ b/src/impls/$peekerate/README.md
@@ -1,18 +1,59 @@
-Turns `source` into a peekerator (often shortened to `peekr`), which is conceptually equivalent to an iterator but is often easier to work with. Peekerators always have a `{done, value}` step from the source iterator stored as `peekr.current`. For convenience `peekr.done` and `peekr.value` are also present. To load the next step call `peekr.advance()`. No value is returned.
-
-Peekerators allow an iterator to be used as internal state. Normal iterators are of course stateful, but less useful for this purpose as it is not possible to access their state without altering it. Peekerators are also have safer typedefs than iterators.
+Turns `source` into a peekerator (often shortened to `peekr`), which is conceptually equivalent to an iterator but is often easier to work with. Peekerators always have a `current` step (of the shape `{ done, value }`) from the source iterator stored as `peekr.current`. This stateful API is useful since it allows you to see the current step without consuming it. This way you can choose to do nothing so that another part of your code will have the chance to act on the value instead. This is highly value in a number of common scenarios. A simple and common one is reacting when an iterable is empty:
 
 ```js
-const peekerator = peekerate([0, 1, 2]);
+function printValues(values) {
+  const peekr = peekerate(values);
 
-while (!peekerator.done) {
-  log(peekerator.value + 1);
-  peekerator.advance();
+  return peekr.done
+    ? 'none'
+    : stringFrom(interposeSeq(', ', peekr.asIterator()));
 }
 
-// logs 1, 2, 3
+printValues([]); // 'none'
+printValues([1, 2, 3]); // '1, 2, 3'
 ```
 
-Also exported is the `Peekerator` base class. Instances should be made using `Peekerator.from(iteratable)`.
+Here is the full interface that the `peekr` object conforms to:
 
-Note that in typescript definitions `Peekerator` is a type not a class, so if you need the class e.g. for `extends` or `instanceof` I have included an alias for `Peekerator` named `PeekeratorClass`. The alias has different typedefs that are less safe but also will not throw errors on value usages.
+```ts
+interface Peekerator<T> {
+  /**
+   * Calls `next()` on the underlying iterator and stores the value in `current`.
+   * Returns `this` for chaining.
+   */
+  advance(): this;
+  /**
+   * Calls `return()` on the underlying iterator.
+   * Returns `this` for chaining.
+   */
+  return(): this;
+  /**
+   * Returns an iterable iterator which starts at the `current` step.
+   * This means that equal(source, peekerate(source).asIterator()) is true
+   */
+  asIterator(): $IterableIterator<T>;
+
+  /**
+   * Returns the step object that was return by `next()`.
+   * The actual typedefs define a tagged union for safety.
+   */
+  readonly current: { done: boolean; value: T | undefined };
+
+  /**
+   * A convenince getter for `current.done`
+   */
+  readonly done: boolean;
+
+  /**
+   * A convenince getter for `current.value`
+   */
+  readonly value: T;
+
+  /**
+   * The index of the step stored in `current`
+   */
+  readonly index: number;
+}
+```
+
+Typescript note: The type of `peekr` (and `peekr.current`) will be refined when you use the value of `peekr.done` as a condition. This helps you avoid spurious errors about `peekr.value` potentially being `undefined`, but it gives rise to another problem: Tyescript doesn't understand that `peekr.advance()` makes its previous refinements invalid. Therefore you must help typescript understand this by writing `peekr = peekr.advance()`. If you do not do this you may discover that Typescript fails to catch some errors, or you may just give strange-looking errors about the type of `peekr` being `never`. This happens because typescript has refined the type of `peekr.done` twice, once to `true` and once to `false`. The type of `true & false` is `never` in Typescript.

--- a/src/impls/$peekerate/__tests__/$peekerate.test.js
+++ b/src/impls/$peekerate/__tests__/$peekerate.test.js
@@ -1,7 +1,8 @@
 import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
-import { $peekerate } from 'iter-tools-es';
-import { $wrap } from '../../../test/$helpers.js';
+import { $peekerate, $str, $interposeSeq } from 'iter-tools-es';
+import { $wrap, anyType } from '../../../test/$helpers.js';
+import { $Iterable } from '../../../types/$iterable.js';
 
 describe($`peekerate`, () => {
   it(
@@ -44,4 +45,71 @@ describe($`peekerate`, () => {
       ]);
     }),
   );
+
+  describe('asIterator', () => {
+    // eslint-disable-next-line jest/expect-expect
+    it(
+      'cleans up source iterable',
+      $async(() => {
+        $await($peekerate($wrap([1, 2, 3])))
+          .asIterator()
+          .return();
+      }),
+    );
+  });
+
+  describe('documentation examples', () => {
+    it(
+      'README example works',
+      $async(() => {
+        const printValues = $async((values: $Iterable<number>) => {
+          const peekr = $await($peekerate(values));
+
+          return peekr.done ? 'none' : $await($str($interposeSeq(', ', peekr.asIterator())));
+        });
+
+        expect($await(printValues($wrap([])))).toBe('none');
+        expect($await(printValues($wrap([1, 2, 3])))).toBe('1, 2, 3');
+      }),
+    );
+
+    it(
+      'cookbook example works',
+      $async(() => {
+        const printListEN = $async((values: $Iterable<number>, oxfordComma = true) => {
+          let peekr = $await($peekerate(values));
+          let result = '';
+          let last = peekr.current;
+
+          if (peekr.done) return 'none';
+
+          while (!peekr.done) {
+            last = peekr.current;
+            peekr = $await(peekr.advance());
+            if (!peekr.done) {
+              if (peekr.index > 1) result += ', ';
+              result += last.value.toString();
+            }
+          }
+
+          if (peekr.index > 2) {
+            if (oxfordComma) {
+              result += ', ';
+            }
+            result += 'and ';
+          } else if (peekr.index > 1) {
+            result += ' and ';
+          }
+
+          result += anyType(last.value).toString();
+          return result;
+        });
+
+        expect($await(printListEN($wrap([])))).toBe('none');
+        expect($await(printListEN($wrap([1])))).toBe('1');
+        expect($await(printListEN($wrap([1, 2])))).toBe('1 and 2');
+        expect($await(printListEN($wrap([1, 2, 3])))).toBe('1, 2, and 3');
+      }),
+    );
+  });
 });

--- a/src/impls/$peekerate/__tests__/peekerate.auto.spec.ts
+++ b/src/impls/$peekerate/__tests__/peekerate.auto.spec.ts
@@ -6,8 +6,9 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { peekerate } from 'iter-tools-es';
-import { wrap } from '../../../test/helpers.js';
+import { peekerate, str, interposeSeq } from 'iter-tools-es';
+import { wrap, anyType } from '../../../test/helpers.js';
+import { Iterable } from '../../../types/iterable.js';
 
 describe('peekerate', () => {
   it('decorates iterator with the current value in the iterable', () => {
@@ -46,5 +47,63 @@ describe('peekerate', () => {
         value: 3,
       },
     ]);
+  });
+
+  describe('asIterator', () => {
+    // eslint-disable-next-line jest/expect-expect
+    it('cleans up source iterable', () => {
+      peekerate(wrap([1, 2, 3]))
+        .asIterator()
+        .return();
+    });
+  });
+
+  describe('documentation examples', () => {
+    it('README example works', () => {
+      const printValues = (values: Iterable<number>) => {
+        const peekr = peekerate(values);
+
+        return peekr.done ? 'none' : str(interposeSeq(', ', peekr.asIterator()));
+      };
+
+      expect(printValues(wrap([]))).toBe('none');
+      expect(printValues(wrap([1, 2, 3]))).toBe('1, 2, 3');
+    });
+
+    it('cookbook example works', () => {
+      const printListEN = (values: Iterable<number>, oxfordComma = true) => {
+        let peekr = peekerate(values);
+        let result = '';
+        let last = peekr.current;
+
+        if (peekr.done) return 'none';
+
+        while (!peekr.done) {
+          last = peekr.current;
+          peekr = peekr.advance();
+          if (!peekr.done) {
+            if (peekr.index > 1) result += ', ';
+            result += last.value.toString();
+          }
+        }
+
+        if (peekr.index > 2) {
+          if (oxfordComma) {
+            result += ', ';
+          }
+          result += 'and ';
+        } else if (peekr.index > 1) {
+          result += ' and ';
+        }
+
+        result += anyType(last.value).toString();
+        return result;
+      };
+
+      expect(printListEN(wrap([]))).toBe('none');
+      expect(printListEN(wrap([1]))).toBe('1');
+      expect(printListEN(wrap([1, 2]))).toBe('1 and 2');
+      expect(printListEN(wrap([1, 2, 3]))).toBe('1, 2, and 3');
+    });
   });
 });

--- a/src/impls/$peekerate/__tests__/peekerate.test.js
+++ b/src/impls/$peekerate/__tests__/peekerate.test.js
@@ -6,8 +6,9 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { peekerate } from 'iter-tools-es';
-import { wrap } from '../../../test/helpers.js';
+import { peekerate, str, interposeSeq } from 'iter-tools-es';
+import { wrap, anyType } from '../../../test/helpers.js';
+import { Iterable } from '../../../types/iterable.js';
 
 describe('peekerate', () => {
   it('decorates iterator with the current value in the iterable', () => {
@@ -46,5 +47,63 @@ describe('peekerate', () => {
         value: 3,
       },
     ]);
+  });
+
+  describe('asIterator', () => {
+    // eslint-disable-next-line jest/expect-expect
+    it('cleans up source iterable', () => {
+      peekerate(wrap([1, 2, 3]))
+        .asIterator()
+        .return();
+    });
+  });
+
+  describe('documentation examples', () => {
+    it('README example works', () => {
+      const printValues = (values: Iterable<number>) => {
+        const peekr = peekerate(values);
+
+        return peekr.done ? 'none' : str(interposeSeq(', ', peekr.asIterator()));
+      };
+
+      expect(printValues(wrap([]))).toBe('none');
+      expect(printValues(wrap([1, 2, 3]))).toBe('1, 2, 3');
+    });
+
+    it('cookbook example works', () => {
+      const printListEN = (values: Iterable<number>, oxfordComma = true) => {
+        let peekr = peekerate(values);
+        let result = '';
+        let last = peekr.current;
+
+        if (peekr.done) return 'none';
+
+        while (!peekr.done) {
+          last = peekr.current;
+          peekr = peekr.advance();
+          if (!peekr.done) {
+            if (peekr.index > 1) result += ', ';
+            result += last.value.toString();
+          }
+        }
+
+        if (peekr.index > 2) {
+          if (oxfordComma) {
+            result += ', ';
+          }
+          result += 'and ';
+        } else if (peekr.index > 1) {
+          result += ' and ';
+        }
+
+        result += anyType(last.value).toString();
+        return result;
+      };
+
+      expect(printListEN(wrap([]))).toBe('none');
+      expect(printListEN(wrap([1]))).toBe('1');
+      expect(printListEN(wrap([1, 2]))).toBe('1 and 2');
+      expect(printListEN(wrap([1, 2, 3]))).toBe('1, 2, and 3');
+    });
   });
 });

--- a/src/impls/$peekerate/async-peekerate.d.ts
+++ b/src/impls/$peekerate/async-peekerate.d.ts
@@ -6,27 +6,37 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { AsyncSourceIterable } from '../../types/async-iterable';
+import { AsyncSourceIterable, AsyncIteratorResult } from '../../types/async-iterable';
 
-interface AsyncPeekeratorBase {
-  advance(): Promise<void>;
-  return(): Promise<void>;
-  readonly index: number;
+export interface AsyncPeekeratorIterator<T> {
+  next(): AsyncIteratorResult<T>;
+  return(): AsyncIteratorResult<T>;
+  [Symbol.asyncIterator](): this;
 }
 
-interface AsyncDonePeekerator extends AsyncPeekeratorBase {
+interface AsyncPeekeratorBase<T> {
+  readonly index: number;
+
+  /* eslint-disable no-use-before-define */
+  advance(): Promise<AsyncPeekerator<T>>;
+  return(): Promise<AsyncPeekerator<T>>;
+  /* eslint-enaable no-use-before-define */
+  asIterator(): AsyncPeekeratorIterator<T>;
+}
+
+interface AsyncDonePeekerator<T> extends AsyncPeekeratorBase<T> {
   readonly current: { done: true; value: undefined };
   readonly done: true;
   readonly value: undefined;
 }
 
-interface AsyncValuePeekerator<T> extends AsyncPeekeratorBase {
+interface AsyncValuePeekerator<T> extends AsyncPeekeratorBase<T> {
   readonly current: { done: false; value: T };
   readonly done: false;
   readonly value: T;
 }
 
-export type AsyncPeekerator<T> = AsyncDonePeekerator | AsyncValuePeekerator<T>;
+export type AsyncPeekerator<T> = AsyncDonePeekerator<T> | AsyncValuePeekerator<T>;
 
 declare function asyncPeekerate<T>(source: AsyncSourceIterable<T>): AsyncPeekerator<T>;
 

--- a/src/impls/$peekerate/peekerate.d.ts
+++ b/src/impls/$peekerate/peekerate.d.ts
@@ -6,27 +6,37 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { SourceIterable } from '../../types/iterable';
+import { SourceIterable, IteratorResult } from '../../types/iterable';
 
-interface PeekeratorBase {
-  advance(): void;
-  return(): void;
-  readonly index: number;
+export interface PeekeratorIterator<T> {
+  next(): IteratorResult<T>;
+  return(): IteratorResult<T>;
+  [Symbol.iterator](): this;
 }
 
-interface DonePeekerator extends PeekeratorBase {
+interface PeekeratorBase<T> {
+  readonly index: number;
+
+  /* eslint-disable no-use-before-define */
+  advance(): Peekerator<T>;
+  return(): Peekerator<T>;
+  /* eslint-enaable no-use-before-define */
+  asIterator(): PeekeratorIterator<T>;
+}
+
+interface DonePeekerator<T> extends PeekeratorBase<T> {
   readonly current: { done: true; value: undefined };
   readonly done: true;
   readonly value: undefined;
 }
 
-interface ValuePeekerator<T> extends PeekeratorBase {
+interface ValuePeekerator<T> extends PeekeratorBase<T> {
   readonly current: { done: false; value: T };
   readonly done: false;
   readonly value: T;
 }
 
-export type Peekerator<T> = DonePeekerator | ValuePeekerator<T>;
+export type Peekerator<T> = DonePeekerator<T> | ValuePeekerator<T>;
 
 declare function peekerate<T>(source: SourceIterable<T>): Peekerator<T>;
 

--- a/src/internal/peekerator.js
+++ b/src/internal/peekerator.js
@@ -10,6 +10,27 @@ import { ensureIterable, callReturn } from './iterable.js';
 
 const _ = Symbol.for('_');
 
+class PeekeratorIterator {
+  constructor(peekr) {
+    this.peekr = peekr;
+  }
+
+  next() {
+    const { peekr } = this;
+    const { current } = peekr;
+    peekr.advance();
+    return current;
+  }
+
+  return() {
+    this.peekr.return();
+  }
+
+  [Symbol.iterator]() {
+    return this;
+  }
+}
+
 export class Peekerator {
   static from(iterable, ...args) {
     const iterator = ensureIterable(iterable)[Symbol.iterator]();
@@ -38,13 +59,18 @@ export class Peekerator {
   }
 
   get index() {
-    return this[_].current.index;
+    return this[_].index;
   }
 
   advance() {
     const this_ = this[_];
+    const { current, iterator } = this_;
+
+    if (current.done) return;
+
     this_.index++;
-    this_.current = this_.iterator.next();
+    this_.current = iterator.next();
+    return this;
   }
 
   return() {
@@ -53,5 +79,10 @@ export class Peekerator {
       callReturn(this_.iterator);
     }
     this_.current = { value: undefined, done: true };
+    return this;
+  }
+
+  asIterator() {
+    return new PeekeratorIterator(this);
   }
 }

--- a/src/types/async-iterable.d.ts
+++ b/src/types/async-iterable.d.ts
@@ -7,10 +7,12 @@ export type AsyncSourceIterable<T> = null | undefined | AsyncDefinedSourceIterab
 type _AsyncIterable<T> = AsyncIterable<T>;
 export { _AsyncIterable as AsyncIterable };
 
+export type AsyncIteratorResult<T> = Promise<IteratorResult<T>>;
+
 export interface AsyncResultIterable<T> {
-  next(value?: any): Promise<IteratorResult<T>>;
-  return(value?: any): Promise<IteratorResult<T>>;
-  throw(e?: any): Promise<IteratorResult<T>>;
+  next(value?: any): AsyncIteratorResult<T>;
+  return(value?: any): AsyncIteratorResult<T>;
+  throw(e?: any): AsyncIteratorResult<T>;
   [Symbol.asyncIterator](): this;
 }
 

--- a/src/types/iterable.d.ts
+++ b/src/types/iterable.d.ts
@@ -7,6 +7,9 @@ export type SourceIterable<T> = DefinedSourceIterable<T> | null | undefined;
 type _Iterable<T> = Iterable<T>;
 export { _Iterable as Iterable };
 
+type _IteratorResult<T> = IteratorResult<T>;
+export { _IteratorResult as IteratorResult };
+
 export interface ResultIterable<T> {
   next(value?: any): IteratorResult<T>;
   return(value?: any): IteratorResult<T>;


### PR DESCRIPTION
Yeah these had some usability problems, especially in TS code. `index` was always `undefined`. Coverage for the implementation and types is much more solid now. Docs are a lot better too. They should be all ready to take over for the now-deceased `nullOr`.