### PR TITLE
Add no-done-value lint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,7 @@ module.exports = {
     'no-return-await': 'off',
     // Pure comments are usually inserted by transpilers, so bundlers expect an exact match.
     'spaced-comment': ['error', 'always', { exceptions: ['#__PURE__'] }],
+    'local-rules/no-done-value': 'error',
   },
   globals: {
     never: 'readonly',

--- a/babel/lint-rules/index.cjs
+++ b/babel/lint-rules/index.cjs
@@ -1,3 +1,4 @@
 module.exports = {
   'no-impure-calls': require('./no-impure-calls.cjs'),
+  'no-done-value': require('./no-done-value.cjs'),
 };

--- a/babel/lint-rules/no-done-value.cjs
+++ b/babel/lint-rules/no-done-value.cjs
@@ -1,0 +1,44 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      description: 'Require iterator step objects to be { value, done } for speed',
+    },
+    fixable: 'code',
+    schema: [], // no options
+  },
+  create: function (context) {
+    return {
+      ObjectExpression(node) {
+        const { properties } = node;
+        if (properties.length >= 2) {
+          let foundDone = false;
+          let foundValue = false;
+          let i = 0;
+          let valid = true;
+          for (const prop of properties) {
+            if (prop.key) {
+              if (prop.key.name === 'value') {
+                foundValue = true;
+                valid = i === 0;
+              }
+              if (prop.key.name === 'done') {
+                foundDone = true;
+                valid = i === 1;
+              }
+            }
+            i++;
+          }
+
+          if (foundDone && foundValue && !valid) {
+            context.report(
+              node,
+              '{ value, done } must be the first keys in an iterator step object (in that order).',
+            );
+          }
+        }
+      },
+    };
+  },
+};

--- a/babel/lint-rules/no-impure-calls.cjs
+++ b/babel/lint-rules/no-impure-calls.cjs
@@ -14,7 +14,7 @@ module.exports = {
     type: 'problem',
 
     docs: {
-      description: 'require calls to curry to be marked pure',
+      description: 'Ensure no impure calls are made',
     },
     fixable: 'code',
     schema: [], // no options
@@ -24,7 +24,7 @@ module.exports = {
     const calls = [];
 
     return {
-      CallExpression(node, path) {
+      CallExpression(node) {
         if (!nearestFunctionScope(context.getScope())) {
           calls.push(node);
         }

--- a/src/impls/$interleave/$interleave.js
+++ b/src/impls/$interleave/$interleave.js
@@ -65,7 +65,7 @@ export class $InputSummary {
   }
 
   get current() {
-    return { done: this.done, value: this.value };
+    return { value: this.value, done: this.done };
   }
 
   get value() {

--- a/src/impls/$interleave/async-interleave.js
+++ b/src/impls/$interleave/async-interleave.js
@@ -68,7 +68,7 @@ export class AsyncInputSummary {
   }
 
   get current() {
-    return { done: this.done, value: this.value };
+    return { value: this.value, done: this.done };
   }
 
   get value() {

--- a/src/impls/$interleave/interleave.js
+++ b/src/impls/$interleave/interleave.js
@@ -68,7 +68,7 @@ export class InputSummary {
   }
 
   get current() {
-    return { done: this.done, value: this.value };
+    return { value: this.value, done: this.done };
   }
 
   get value() {

--- a/src/impls/$peekerate/__tests__/$peekerate.test.js
+++ b/src/impls/$peekerate/__tests__/$peekerate.test.js
@@ -12,35 +12,35 @@ describe($`peekerate`, () => {
       const observed = [];
 
       while (!peekerator.done) {
-        const { current, done, value } = peekerator;
-        observed.push({ current, done, value });
+        const { value, done, current } = peekerator;
+        observed.push({ value, done, current });
         $await(peekerator.advance());
       }
 
       expect(observed).toEqual([
         {
-          current: {
-            done: false,
-            value: 1,
-          },
-          done: false,
           value: 1,
+          done: false,
+          current: {
+            value: 1,
+            done: false,
+          },
         },
         {
-          current: {
-            done: false,
-            value: 2,
-          },
-          done: false,
           value: 2,
+          done: false,
+          current: {
+            value: 2,
+            done: false,
+          },
         },
         {
-          current: {
-            done: false,
-            value: 3,
-          },
-          done: false,
           value: 3,
+          done: false,
+          current: {
+            value: 3,
+            done: false,
+          },
         },
       ]);
     }),

--- a/src/impls/$peekerate/__tests__/async-peekerate.auto.spec.ts
+++ b/src/impls/$peekerate/__tests__/async-peekerate.auto.spec.ts
@@ -16,35 +16,35 @@ describe('asyncPeekerate', () => {
     const observed = [];
 
     while (!peekerator.done) {
-      const { current, done, value } = peekerator;
-      observed.push({ current, done, value });
+      const { value, done, current } = peekerator;
+      observed.push({ value, done, current });
       await peekerator.advance();
     }
 
     expect(observed).toEqual([
       {
-        current: {
-          done: false,
-          value: 1,
-        },
-        done: false,
         value: 1,
+        done: false,
+        current: {
+          value: 1,
+          done: false,
+        },
       },
       {
-        current: {
-          done: false,
-          value: 2,
-        },
-        done: false,
         value: 2,
+        done: false,
+        current: {
+          value: 2,
+          done: false,
+        },
       },
       {
-        current: {
-          done: false,
-          value: 3,
-        },
-        done: false,
         value: 3,
+        done: false,
+        current: {
+          value: 3,
+          done: false,
+        },
       },
     ]);
   });

--- a/src/impls/$peekerate/__tests__/async-peekerate.test.js
+++ b/src/impls/$peekerate/__tests__/async-peekerate.test.js
@@ -16,35 +16,35 @@ describe('asyncPeekerate', () => {
     const observed = [];
 
     while (!peekerator.done) {
-      const { current, done, value } = peekerator;
-      observed.push({ current, done, value });
+      const { value, done, current } = peekerator;
+      observed.push({ value, done, current });
       await peekerator.advance();
     }
 
     expect(observed).toEqual([
       {
-        current: {
-          done: false,
-          value: 1,
-        },
-        done: false,
         value: 1,
+        done: false,
+        current: {
+          value: 1,
+          done: false,
+        },
       },
       {
-        current: {
-          done: false,
-          value: 2,
-        },
-        done: false,
         value: 2,
+        done: false,
+        current: {
+          value: 2,
+          done: false,
+        },
       },
       {
-        current: {
-          done: false,
-          value: 3,
-        },
-        done: false,
         value: 3,
+        done: false,
+        current: {
+          value: 3,
+          done: false,
+        },
       },
     ]);
   });

--- a/src/impls/$peekerate/__tests__/peekerate.auto.spec.ts
+++ b/src/impls/$peekerate/__tests__/peekerate.auto.spec.ts
@@ -16,35 +16,35 @@ describe('peekerate', () => {
     const observed = [];
 
     while (!peekerator.done) {
-      const { current, done, value } = peekerator;
-      observed.push({ current, done, value });
+      const { value, done, current } = peekerator;
+      observed.push({ value, done, current });
       peekerator.advance();
     }
 
     expect(observed).toEqual([
       {
-        current: {
-          done: false,
-          value: 1,
-        },
-        done: false,
         value: 1,
+        done: false,
+        current: {
+          value: 1,
+          done: false,
+        },
       },
       {
-        current: {
-          done: false,
-          value: 2,
-        },
-        done: false,
         value: 2,
+        done: false,
+        current: {
+          value: 2,
+          done: false,
+        },
       },
       {
-        current: {
-          done: false,
-          value: 3,
-        },
-        done: false,
         value: 3,
+        done: false,
+        current: {
+          value: 3,
+          done: false,
+        },
       },
     ]);
   });

--- a/src/impls/$peekerate/__tests__/peekerate.test.js
+++ b/src/impls/$peekerate/__tests__/peekerate.test.js
@@ -16,35 +16,35 @@ describe('peekerate', () => {
     const observed = [];
 
     while (!peekerator.done) {
-      const { current, done, value } = peekerator;
-      observed.push({ current, done, value });
+      const { value, done, current } = peekerator;
+      observed.push({ value, done, current });
       peekerator.advance();
     }
 
     expect(observed).toEqual([
       {
-        current: {
-          done: false,
-          value: 1,
-        },
-        done: false,
         value: 1,
+        done: false,
+        current: {
+          value: 1,
+          done: false,
+        },
       },
       {
-        current: {
-          done: false,
-          value: 2,
-        },
-        done: false,
         value: 2,
+        done: false,
+        current: {
+          value: 2,
+          done: false,
+        },
       },
       {
-        current: {
-          done: false,
-          value: 3,
-        },
-        done: false,
         value: 3,
+        done: false,
+        current: {
+          value: 3,
+          done: false,
+        },
       },
     ]);
   });


### PR DESCRIPTION
Looks like we weren't violating this one, but in the few places we write our own iterators it's crucial that the step objects are of the shape `{ value, done }` not `{ done, value }` because that is what generators make and mixing the two will result in costly deopts in modern compilers.