### PR TITLE
Make zip and zipAll typings generic

### DIFF
--- a/src/impls/$zip-all/$zip-all.d.ts
+++ b/src/impls/$zip-all/$zip-all.d.ts
@@ -1,36 +1,16 @@
-import { $Wrappable, $IterableIterator } from '../../types/$iterable';
+import { $Wrappable, $IterableIterator, $Unwrap } from '../../types/$iterable';
 
-declare function $zipAll<F, T, U>(
+type ZipAll<Sources extends $Wrappable<unknown>[], Filler> = {
+  [index in keyof Sources]: $Unwrap<Sources[index]> | Filler;
+};
+
+declare function $zipAll<F, Sources extends $Wrappable<unknown>[]>(
   options: { filler?: F },
-  source1: $Wrappable<T>,
-  source2: $Wrappable<U>,
-): $IterableIterator<[T | F, U | F]>;
+  ...sources: Sources
+): $IterableIterator<ZipAll<Sources, F>>;
 
-declare function $zipAll<T, U>(
-  source1: $Wrappable<T>,
-  source2: $Wrappable<U>,
-): $IterableIterator<[T | undefined, U | undefined]>;
-
-declare function $zipAll<F, T, U, V>(
-  options: { filler?: F },
-  source1: $Wrappable<T>,
-  source2: $Wrappable<U>,
-  source3: $Wrappable<V>,
-): $IterableIterator<[T | F, U | F, V | F]>;
-
-declare function $zipAll<T, U, V>(
-  source1: $Wrappable<T>,
-  source2: $Wrappable<U>,
-  source3: $Wrappable<V>,
-): $IterableIterator<[T | undefined, U | undefined, V | undefined]>;
-
-declare function $zipAll<F, T>(
-  options: { filler?: F },
-  ...sources: Array<$Wrappable<T>>
-): $IterableIterator<Array<T | F>>;
-
-declare function $zipAll<T>(
-  ...sources: Array<$Wrappable<T>>
-): $IterableIterator<Array<T | undefined>>;
+declare function $zipAll<Sources extends $Wrappable<unknown>[]>(
+  ...sources: Sources
+): $IterableIterator<ZipAll<Sources, undefined>>;
 
 export { $zipAll };

--- a/src/impls/$zip-all/async-zip-all.d.ts
+++ b/src/impls/$zip-all/async-zip-all.d.ts
@@ -6,39 +6,19 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { AsyncWrappable, AsyncIterableIterator } from '../../types/async-iterable';
+import { AsyncWrappable, AsyncIterableIterator, AsyncUnwrap } from '../../types/async-iterable';
 
-declare function asyncZipAll<F, T, U>(
+type ZipAll<Sources extends AsyncWrappable<unknown>[], Filler> = {
+  [index in keyof Sources]: AsyncUnwrap<Sources[index]> | Filler;
+};
+
+declare function asyncZipAll<F, Sources extends AsyncWrappable<unknown>[]>(
   options: { filler?: F },
-  source1: AsyncWrappable<T>,
-  source2: AsyncWrappable<U>,
-): AsyncIterableIterator<[T | F, U | F]>;
+  ...sources: Sources
+): AsyncIterableIterator<ZipAll<Sources, F>>;
 
-declare function asyncZipAll<T, U>(
-  source1: AsyncWrappable<T>,
-  source2: AsyncWrappable<U>,
-): AsyncIterableIterator<[T | undefined, U | undefined]>;
-
-declare function asyncZipAll<F, T, U, V>(
-  options: { filler?: F },
-  source1: AsyncWrappable<T>,
-  source2: AsyncWrappable<U>,
-  source3: AsyncWrappable<V>,
-): AsyncIterableIterator<[T | F, U | F, V | F]>;
-
-declare function asyncZipAll<T, U, V>(
-  source1: AsyncWrappable<T>,
-  source2: AsyncWrappable<U>,
-  source3: AsyncWrappable<V>,
-): AsyncIterableIterator<[T | undefined, U | undefined, V | undefined]>;
-
-declare function asyncZipAll<F, T>(
-  options: { filler?: F },
-  ...sources: Array<AsyncWrappable<T>>
-): AsyncIterableIterator<Array<T | F>>;
-
-declare function asyncZipAll<T>(
-  ...sources: Array<AsyncWrappable<T>>
-): AsyncIterableIterator<Array<T | undefined>>;
+declare function asyncZipAll<Sources extends AsyncWrappable<unknown>[]>(
+  ...sources: Sources
+): AsyncIterableIterator<ZipAll<Sources, undefined>>;
 
 export { asyncZipAll };

--- a/src/impls/$zip-all/zip-all.d.ts
+++ b/src/impls/$zip-all/zip-all.d.ts
@@ -6,37 +6,19 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { Wrappable, IterableIterator } from '../../types/iterable';
+import { Wrappable, IterableIterator, Unwrap } from '../../types/iterable';
 
-declare function zipAll<F, T, U>(
+type ZipAll<Sources extends Wrappable<unknown>[], Filler> = {
+  [index in keyof Sources]: Unwrap<Sources[index]> | Filler;
+};
+
+declare function zipAll<F, Sources extends Wrappable<unknown>[]>(
   options: { filler?: F },
-  source1: Wrappable<T>,
-  source2: Wrappable<U>,
-): IterableIterator<[T | F, U | F]>;
+  ...sources: Sources
+): IterableIterator<ZipAll<Sources, F>>;
 
-declare function zipAll<T, U>(
-  source1: Wrappable<T>,
-  source2: Wrappable<U>,
-): IterableIterator<[T | undefined, U | undefined]>;
-
-declare function zipAll<F, T, U, V>(
-  options: { filler?: F },
-  source1: Wrappable<T>,
-  source2: Wrappable<U>,
-  source3: Wrappable<V>,
-): IterableIterator<[T | F, U | F, V | F]>;
-
-declare function zipAll<T, U, V>(
-  source1: Wrappable<T>,
-  source2: Wrappable<U>,
-  source3: Wrappable<V>,
-): IterableIterator<[T | undefined, U | undefined, V | undefined]>;
-
-declare function zipAll<F, T>(
-  options: { filler?: F },
-  ...sources: Array<Wrappable<T>>
-): IterableIterator<Array<T | F>>;
-
-declare function zipAll<T>(...sources: Array<Wrappable<T>>): IterableIterator<Array<T | undefined>>;
+declare function zipAll<Sources extends Wrappable<unknown>[]>(
+  ...sources: Sources
+): IterableIterator<ZipAll<Sources, undefined>>;
 
 export { zipAll };

--- a/src/impls/$zip/$zip.d.ts
+++ b/src/impls/$zip/$zip.d.ts
@@ -1,14 +1,11 @@
-import { $Wrappable, $IterableIterator } from '../../types/$iterable';
+import { $Wrappable, $IterableIterator, $Unwrap } from '../../types/$iterable';
 
-declare function $zip<T, U>(
-  source1: $Wrappable<T>,
-  source2: $Wrappable<U>,
-): $IterableIterator<[T, U]>;
-declare function $zip<T, U, V>(
-  source1: $Wrappable<T>,
-  source2: $Wrappable<U>,
-  source3: $Wrappable<V>,
-): $IterableIterator<[T, U, V]>;
-declare function $zip<T>(...sources: Array<$Wrappable<T>>): $IterableIterator<T[]>;
+type Zip<Sources extends $Wrappable<unknown>[]> = {
+  [index in keyof Sources]: $Unwrap<Sources[index]>;
+};
+
+declare function $zip<Sources extends $Wrappable<unknown>[]>(
+  ...sources: Sources
+): $IterableIterator<Zip<Sources>>;
 
 export { $zip };

--- a/src/impls/$zip/async-zip.d.ts
+++ b/src/impls/$zip/async-zip.d.ts
@@ -6,17 +6,14 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { AsyncWrappable, AsyncIterableIterator } from '../../types/async-iterable';
+import { AsyncWrappable, AsyncIterableIterator, AsyncUnwrap } from '../../types/async-iterable';
 
-declare function asyncZip<T, U>(
-  source1: AsyncWrappable<T>,
-  source2: AsyncWrappable<U>,
-): AsyncIterableIterator<[T, U]>;
-declare function asyncZip<T, U, V>(
-  source1: AsyncWrappable<T>,
-  source2: AsyncWrappable<U>,
-  source3: AsyncWrappable<V>,
-): AsyncIterableIterator<[T, U, V]>;
-declare function asyncZip<T>(...sources: Array<AsyncWrappable<T>>): AsyncIterableIterator<T[]>;
+type Zip<Sources extends AsyncWrappable<unknown>[]> = {
+  [index in keyof Sources]: AsyncUnwrap<Sources[index]>;
+};
+
+declare function asyncZip<Sources extends AsyncWrappable<unknown>[]>(
+  ...sources: Sources
+): AsyncIterableIterator<Zip<Sources>>;
 
 export { asyncZip };

--- a/src/impls/$zip/zip.d.ts
+++ b/src/impls/$zip/zip.d.ts
@@ -6,14 +6,14 @@
  * More information can be found in CONTRIBUTING.md
  */
 
-import { Wrappable, IterableIterator } from '../../types/iterable';
+import { Wrappable, IterableIterator, Unwrap } from '../../types/iterable';
 
-declare function zip<T, U>(source1: Wrappable<T>, source2: Wrappable<U>): IterableIterator<[T, U]>;
-declare function zip<T, U, V>(
-  source1: Wrappable<T>,
-  source2: Wrappable<U>,
-  source3: Wrappable<V>,
-): IterableIterator<[T, U, V]>;
-declare function zip<T>(...sources: Array<Wrappable<T>>): IterableIterator<T[]>;
+type Zip<Sources extends Wrappable<unknown>[]> = {
+  [index in keyof Sources]: Unwrap<Sources[index]>;
+};
+
+declare function zip<Sources extends Wrappable<unknown>[]>(
+  ...sources: Sources
+): IterableIterator<Zip<Sources>>;
 
 export { zip };

--- a/src/types/async-iterable.d.ts
+++ b/src/types/async-iterable.d.ts
@@ -4,6 +4,8 @@
 export type AsyncLoopable<T> = AsyncIterable<T | Promise<T>> | Iterable<T | Promise<T>>;
 export type AsyncWrappable<T> = null | undefined | AsyncLoopable<T>;
 
+export type AsyncUnwrap<T> = T extends AsyncWrappable<infer U> ? U : never;
+
 type _AsyncIterable<T> = AsyncIterable<T>;
 export { _AsyncIterable as AsyncIterable };
 

--- a/src/types/iterable.d.ts
+++ b/src/types/iterable.d.ts
@@ -7,6 +7,8 @@ export { _Iterable as Iterable };
 export type Loopable<T> = Iterable<T>;
 export type Wrappable<T> = Loopable<T> | null | undefined;
 
+export type Unwrap<T> = T extends Wrappable<infer U> ? U : never;
+
 type _IteratorResult<T> = IteratorResult<T>;
 export { _IteratorResult as IteratorResult };
 


### PR DESCRIPTION
I believe I have found a way to type `zip` and `zipAll` with an arbitrary number of arguments. Let's get another set of eyes on this, but if it works, it's much cleaner than special cases for the two and three argument cases.