### PR TITLE
Fixed typo in pipe and compose docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -2602,7 +2602,7 @@ Yields the elements from `source` in reverse order. `source` must be an array, s
 
 **compose(...fns)**  
 
-Allows nested calls to be flattened out for improved readability. `compose(a, b, c)` is equivalent to `a(b(c))`, where `a`, `b`, and `c`, are functions. `compose` is usually combined with curryied forms of other methods so that the `source` (or `iterable`) argument is passed between the composed methods.
+Allows nested calls to be flattened out for improved readability. `compose(a, b, c)(x)` is equivalent to `a(b(c(x)))`, where `a`, `b`, and `c`, are functions. `compose` is usually combined with curryied forms of other methods so that the `source` (or `iterable`) argument is passed between the composed methods.
 
 ```js
 const filterMap = compose(
@@ -2645,7 +2645,7 @@ getSize(null); // 0
 
 **pipe(...fns)**  
 
-Allows nested calls to be flattened out for improved readability. `pipe(a, b, c)` is equivalent to `c(b(a))`, where `a`, `b`, and `c`, are functions. `pipe` is usually combined with curryied forms of other methods so that the `source` (or `iterable`) argument is passed between the composed methods.
+Allows nested calls to be flattened out for improved readability. `pipe(a, b, c)(x)` is equivalent to `c(b(a(x)))`, where `a`, `b`, and `c`, are functions. `pipe` is usually combined with curryied forms of other methods so that the `source` (or `iterable`) argument is passed between the composed methods.
 
 ```js
 const filterMap = pipe(

--- a/src/impls/compose/README.md
+++ b/src/impls/compose/README.md
@@ -1,4 +1,4 @@
-Allows nested calls to be flattened out for improved readability. `compose(a, b, c)` is equivalent to `a(b(c))`, where `a`, `b`, and `c`, are functions. `compose` is usually combined with curryied forms of other methods so that the `source` (or `iterable`) argument is passed between the composed methods.
+Allows nested calls to be flattened out for improved readability. `compose(a, b, c)(x)` is equivalent to `a(b(c(x)))`, where `a`, `b`, and `c`, are functions. `compose` is usually combined with curryied forms of other methods so that the `source` (or `iterable`) argument is passed between the composed methods.
 
 ```js
 const filterMap = compose(

--- a/src/impls/pipe/README.md
+++ b/src/impls/pipe/README.md
@@ -1,4 +1,4 @@
-Allows nested calls to be flattened out for improved readability. `pipe(a, b, c)` is equivalent to `c(b(a))`, where `a`, `b`, and `c`, are functions. `pipe` is usually combined with curryied forms of other methods so that the `source` (or `iterable`) argument is passed between the composed methods.
+Allows nested calls to be flattened out for improved readability. `pipe(a, b, c)(x)` is equivalent to `c(b(a(x)))`, where `a`, `b`, and `c`, are functions. `pipe` is usually combined with curryied forms of other methods so that the `source` (or `iterable`) argument is passed between the composed methods.
 
 ```js
 const filterMap = pipe(


### PR DESCRIPTION
The docs for `pipe` used the expression `c(b(a))`, which means `a` as a function is passed into `b`, which is misleading. What `pipe` really does is the result of `a(x)` is passed into `b`.

I've fixed the `pipe` and `compose` docs to make this more clear by showing `pipe` and `compose` return functions.