### PR TITLE
fix(take): finish the iterable as soon as requested items are took

### DIFF
--- a/src/impls/$take/$take.js
+++ b/src/impls/$take/$take.js
@@ -7,8 +7,8 @@ export function* $__take(iterable, n) {
   let i = 0;
   $await;
   for (const value of iterable) {
-    if (i++ === n) break;
     yield value;
+    if (++i === n) break;
   }
 }
 

--- a/src/impls/$take/$take.js
+++ b/src/impls/$take/$take.js
@@ -4,6 +4,7 @@ import { $iterableCurry } from '../../internal/$iterable.js';
 
 $async;
 export function* $__take(iterable, n) {
+  if (n === 0) return;
   let i = 0;
   $await;
   for (const value of iterable) {

--- a/src/impls/$take/__tests__/$take.test.ts
+++ b/src/impls/$take/__tests__/$take.test.ts
@@ -1,4 +1,4 @@
-import { $, $async, $await } from '../../../../generate/async.macro.cjs';
+import { $, $async, $await, $isAsync } from '../../../../generate/async.macro.cjs';
 
 import { $take } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
@@ -8,6 +8,26 @@ describe($`take`, () => {
     'takes the first n values',
     $async(() => {
       expect($await($unwrap($take(2, $wrap([1, 2, 3]))))).toEqual([1, 2]);
+    }),
+  );
+  it(
+    'completes immediately after taking the first n values',
+    $async(() => {
+      $async;
+      function* twoItemsThenNever() {
+        yield 1;
+        yield 2;
+        // Never yields 3.
+        if ($isAsync) {
+          $await(new Promise(() => undefined));
+        } else {
+          while (true) {
+            // Never ends
+          }
+        }
+        yield 3;
+      }
+      expect($await($unwrap($take(2, twoItemsThenNever())))).toEqual([1, 2]);
     }),
   );
 });

--- a/src/impls/$take/__tests__/$take.test.ts
+++ b/src/impls/$take/__tests__/$take.test.ts
@@ -1,4 +1,4 @@
-import { $, $async, $await, $isAsync } from '../../../../generate/async.macro.cjs';
+import { $, $async, $await } from '../../../../generate/async.macro.cjs';
 
 import { $take } from 'iter-tools-es';
 import { $wrap, $unwrap } from '../../../test/$helpers.js';
@@ -23,15 +23,7 @@ describe($`take`, () => {
       function* twoItemsThenNever() {
         yield 1;
         yield 2;
-        // Never yields 3.
-        if ($isAsync) {
-          $await(new Promise(() => undefined));
-        } else {
-          while (true) {
-            // Never ends
-          }
-        }
-        yield 3;
+        throw new Error('Should not yield after `2`');
       }
       expect($await($unwrap($take(2, twoItemsThenNever())))).toEqual([1, 2]);
     }),

--- a/src/impls/$take/__tests__/$take.test.ts
+++ b/src/impls/$take/__tests__/$take.test.ts
@@ -11,6 +11,12 @@ describe($`take`, () => {
     }),
   );
   it(
+    'completes immediately if requesting 0 (or less) items',
+    $async(() => {
+      expect($await($unwrap($take(0, $wrap([1, 2, 3]))))).toEqual([]);
+    }),
+  );
+  it(
     'completes immediately after taking the first n values',
     $async(() => {
       $async;

--- a/src/impls/$take/__tests__/async-take.test.ts
+++ b/src/impls/$take/__tests__/async-take.test.ts
@@ -13,4 +13,19 @@ describe('asyncTake', () => {
   it('takes the first n values', async () => {
     expect(await asyncUnwrap(asyncTake(2, asyncWrap([1, 2, 3])))).toEqual([1, 2]);
   });
+  it('completes immediately after taking the first n values', async () => {
+    expect(
+      await asyncUnwrap(
+        asyncTake(
+          2,
+          (async function* twoItemsThenNever() {
+            yield 1;
+            yield 2;
+            await new Promise(() => undefined);
+            yield 3;
+          })(),
+        ),
+      ),
+    ).toEqual([1, 2]);
+  });
 });

--- a/src/impls/$take/__tests__/async-take.test.ts
+++ b/src/impls/$take/__tests__/async-take.test.ts
@@ -24,8 +24,7 @@ describe('asyncTake', () => {
           (async function* twoItemsThenNever() {
             yield 1;
             yield 2;
-            await new Promise(() => undefined);
-            yield 3;
+            throw new Error('Should not yield after `2`');
           })(),
         ),
       ),

--- a/src/impls/$take/__tests__/async-take.test.ts
+++ b/src/impls/$take/__tests__/async-take.test.ts
@@ -13,6 +13,9 @@ describe('asyncTake', () => {
   it('takes the first n values', async () => {
     expect(await asyncUnwrap(asyncTake(2, asyncWrap([1, 2, 3])))).toEqual([1, 2]);
   });
+  it('completes immediately if requesting 0 (or less) items', async () => {
+    expect(await asyncUnwrap(asyncTake(0, asyncWrap([1, 2, 3])))).toEqual([]);
+  });
   it('completes immediately after taking the first n values', async () => {
     expect(
       await asyncUnwrap(

--- a/src/impls/$take/__tests__/take.test.ts
+++ b/src/impls/$take/__tests__/take.test.ts
@@ -13,6 +13,9 @@ describe('take', () => {
   it('takes the first n values', () => {
     expect(unwrap(take(2, wrap([1, 2, 3])))).toEqual([1, 2]);
   });
+  it('completes immediately if requesting 0 (or less) items', () => {
+    expect(unwrap(take(0, wrap([1, 2, 3])))).toEqual([]);
+  });
   it('completes immediately after taking the first n values', () => {
     expect(
       unwrap(

--- a/src/impls/$take/__tests__/take.test.ts
+++ b/src/impls/$take/__tests__/take.test.ts
@@ -24,10 +24,7 @@ describe('take', () => {
           (function* twoItemsThenNever() {
             yield 1;
             yield 2;
-            while (true) {
-              // Never ends
-            }
-            yield 3;
+            throw new Error('Should not yield after `2`');
           })(),
         ),
       ),

--- a/src/impls/$take/__tests__/take.test.ts
+++ b/src/impls/$take/__tests__/take.test.ts
@@ -13,4 +13,21 @@ describe('take', () => {
   it('takes the first n values', () => {
     expect(unwrap(take(2, wrap([1, 2, 3])))).toEqual([1, 2]);
   });
+  it('completes immediately after taking the first n values', () => {
+    expect(
+      unwrap(
+        take(
+          2,
+          (function* twoItemsThenNever() {
+            yield 1;
+            yield 2;
+            while (true) {
+              // Never ends
+            }
+            yield 3;
+          })(),
+        ),
+      ),
+    ).toEqual([1, 2]);
+  });
 });

--- a/src/impls/$take/async-take.js
+++ b/src/impls/$take/async-take.js
@@ -9,6 +9,7 @@
 import { asyncIterableCurry } from '../../internal/async-iterable.js';
 
 export async function* __asyncTake(iterable, n) {
+  if (n === 0) return;
   let i = 0;
   for await (const value of iterable) {
     yield value;

--- a/src/impls/$take/async-take.js
+++ b/src/impls/$take/async-take.js
@@ -11,8 +11,8 @@ import { asyncIterableCurry } from '../../internal/async-iterable.js';
 export async function* __asyncTake(iterable, n) {
   let i = 0;
   for await (const value of iterable) {
-    if (i++ === n) break;
     yield value;
+    if (++i === n) break;
   }
 }
 

--- a/src/impls/$take/take.js
+++ b/src/impls/$take/take.js
@@ -9,6 +9,7 @@
 import { iterableCurry } from '../../internal/iterable.js';
 
 export function* __take(iterable, n) {
+  if (n === 0) return;
   let i = 0;
   for (const value of iterable) {
     yield value;

--- a/src/impls/$take/take.js
+++ b/src/impls/$take/take.js
@@ -11,8 +11,8 @@ import { iterableCurry } from '../../internal/iterable.js';
 export function* __take(iterable, n) {
   let i = 0;
   for (const value of iterable) {
-    if (i++ === n) break;
     yield value;
+    if (++i === n) break;
   }
 }
 


### PR DESCRIPTION
`asyncTake` waits for the next iteration item before completing, which may never be yield. The break condition have been slightly modified & moved right after the yield to allow early exits.

While this issue should not happen for sync iterables, those modifications have been reflected on the sync version too.