### PR TITLE
Always return an iterator result from return()

### DIFF
--- a/src/impls/$interleave/$interleave.js
+++ b/src/impls/$interleave/$interleave.js
@@ -125,6 +125,7 @@ class $Interleaver extends $IterableIterator {
   return() {
     $await($callReturn(this.iterator));
     $await(this.returnBuffers());
+    return { value: undefined, done: true };
   }
 }
 

--- a/src/impls/$interleave/async-interleave.js
+++ b/src/impls/$interleave/async-interleave.js
@@ -122,6 +122,7 @@ class AsyncInterleaver extends AsyncIterableIterator {
   async return() {
     await asyncCallReturn(this.iterator);
     await this.returnBuffers();
+    return { value: undefined, done: true };
   }
 }
 

--- a/src/impls/$interleave/interleave.js
+++ b/src/impls/$interleave/interleave.js
@@ -122,6 +122,7 @@ class Interleaver extends IterableIterator {
   return() {
     callReturn(this.iterator);
     this.returnBuffers();
+    return { value: undefined, done: true };
   }
 }
 

--- a/src/internal/$fork.js
+++ b/src/internal/$fork.js
@@ -46,6 +46,7 @@ class $Fork extends $IterableIterator {
     const { done, exchange } = this;
 
     if (!done) $await(exchange.return());
+    return { value: undefined, done: true };
   }
 }
 
@@ -79,5 +80,6 @@ export class $Exchange {
     if (this.forks === 0) {
       $await($callReturn(this.iterator));
     }
+    return { value: undefined, done: true };
   }
 }

--- a/src/internal/$peekerator.js
+++ b/src/internal/$peekerator.js
@@ -20,6 +20,7 @@ class $PeekeratorIterator {
   @$async
   return() {
     $await(this.peekr.return());
+    return { value: undefined, done: true };
   }
 
   [$iteratorSymbol]() {

--- a/src/internal/async-fork.js
+++ b/src/internal/async-fork.js
@@ -50,6 +50,7 @@ class AsyncFork extends AsyncIterableIterator {
     const { done, exchange } = this;
 
     if (!done) await exchange.return();
+    return { value: undefined, done: true };
   }
 }
 
@@ -81,5 +82,6 @@ export class AsyncExchange {
     if (this.forks === 0) {
       await asyncCallReturn(this.iterator);
     }
+    return { value: undefined, done: true };
   }
 }

--- a/src/internal/async-peekerator.js
+++ b/src/internal/async-peekerator.js
@@ -24,6 +24,7 @@ class AsyncPeekeratorIterator {
 
   async return() {
     await this.peekr.return();
+    return { value: undefined, done: true };
   }
 
   [Symbol.asyncIterator]() {

--- a/src/internal/fork.js
+++ b/src/internal/fork.js
@@ -50,6 +50,7 @@ class Fork extends IterableIterator {
     const { done, exchange } = this;
 
     if (!done) exchange.return();
+    return { value: undefined, done: true };
   }
 }
 
@@ -81,5 +82,6 @@ export class Exchange {
     if (this.forks === 0) {
       callReturn(this.iterator);
     }
+    return { value: undefined, done: true };
   }
 }

--- a/src/internal/peekerator.js
+++ b/src/internal/peekerator.js
@@ -24,6 +24,7 @@ class PeekeratorIterator {
 
   return() {
     this.peekr.return();
+    return { value: undefined, done: true };
   }
 
   [Symbol.iterator]() {


### PR DESCRIPTION
Fixes: #463

It seems that certain engines now error if the promise returned from `iter.return()` is not a step object.