### PR TITLE
Allow importing from ./__methods

### DIFF
--- a/package.es.json
+++ b/package.es.json
@@ -11,6 +11,9 @@
       "import": "./methods/*.mjs",
       "require": "./methods/*.js"
     },
+    "./__methods/*": {
+      "require": "./__methods/*.js"
+    },
     "./explode.macro": "./explode.macro.js",
     "./package.json": "./package.json"
   },

--- a/package.es5.json
+++ b/package.es5.json
@@ -12,6 +12,9 @@
       "import": "./methods/*.mjs",
       "require": "./methods/*.js"
     },
+    "./__methods/*": {
+      "require": "./__methods/*.js"
+    },
     "./explode.macro": "./explode.macro.js",
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "./methods/*": {
       "import": "./src/methods/*.js"
     },
+    "./__methods/*": {
+      "import": "./src/__methods/*.js"
+    },
     "./explode.macro": "./src/explode.macro.cjs",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Not sure if I've missed an alternative way to import the __ methods, but e.g. `import __take from 'iter-tools/__methods/take'` doesn't work without adding the directory to the export map.