### PR TITLE
Add types to the exports fields

### DIFF
--- a/package.es.json
+++ b/package.es.json
@@ -5,11 +5,13 @@
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "types": "./index.d.ts"
     },
     "./methods/*": {
       "import": "./methods/*.mjs",
-      "require": "./methods/*.js"
+      "require": "./methods/*.js",
+      "types": "./methods/*.d.ts"
     },
     "./__methods/*": {
       "require": "./__methods/*.js"

--- a/package.es5.json
+++ b/package.es5.json
@@ -6,11 +6,13 @@
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "types": "./index.d.ts"
     },
     "./methods/*": {
       "import": "./methods/*.mjs",
-      "require": "./methods/*.js"
+      "require": "./methods/*.js",
+      "types": "./methods/*.d.ts"
     },
     "./__methods/*": {
       "require": "./__methods/*.js"

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "main": "src/index.js",
   "exports": {
     ".": {
-      "import": "./src/index.js"
+      "import": "./src/index.js",
+      "types": "./src/index.d.ts"
     },
     "./methods/*": {
-      "import": "./src/methods/*.js"
+      "import": "./src/methods/*.js",
+      "types": "./src/methods/*.d.ts"
     },
     "./__methods/*": {
       "import": "./src/__methods/*.js"


### PR DESCRIPTION
Fixes https://github.com/iter-tools/iter-tools/issues/490

I checked that it works correctly as a local dependency.
