### PR TITLE
dX.Y.Z tags to allow doc updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Choose whether to make a major, minor, or patch release in accordance with the s
 
 In `package.json` update the `version` field.
 
-In `README.md` update the "API docs" link with the tag for the version being released. The link would be to `https://github.com/iter-tools/iter-tools/blob/v1.2.3/API.md`. This prevents users seeing documentation for unreleased features.
+In `README.md` update the "API docs" link with the tag for the version being released. The link would be to `https://github.com/iter-tools/iter-tools/blob/d1.2.3/API.md`. This prevents users seeing documentation for unreleased features.
 
 In `CHANGELOG.md` fill in the version and date of the release, and make sure there is a new blank `UNRELEASED` section at the top of the file. Patch releases generally should not require changelog updates -- that is what the issue tracker is for.
 
@@ -155,7 +155,7 @@ Double check everything. You are pushing to trunk, so no take-backs. CI cannot h
 
 `yarn build`
 
-`git commit -am 1.2.3 && git tag v1.2.3`
+`git commit -am 1.2.3 && git tag v1.2.3 && git tag d1.2.3`
 
 `git push && git push --tags`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ es5 consumers are responsible for loading `core-js` if their environment does no
 
 ## API
 
-**Please read our [API docs](https://github.com/iter-tools/iter-tools/blob/v7.5.0/API.md)!**
+**Please read our [API docs](https://github.com/iter-tools/iter-tools/blob/d7.5.0/API.md)!**
 
 Historical docs are markdown files on github. For 6.x docs look at tags on the history of [README.md](https://github.com/iter-tools/iter-tools/blob/6.x/README.md). For 7.x versions look at tags on the history of [API.md](https://github.com/iter-tools/iter-tools/blob/trunk/API.md).
 


### PR DESCRIPTION
Fixes the problem that we can't fix typos and such in the API docs without releasing a new version of the package. We want to preserve the `v` tags to denote the commits published on npm, but the `d` tags will allow the linked docs to be directed elsewhere so that old docs can be corrected while still allowing the API docs for `trunk` to be in a between-versions state.